### PR TITLE
통합 예외 처리를 위한 HttpExceptionHandler 구현

### DIFF
--- a/backend/src/main/java/dev/be/dorothy/exception/HttpExceptionHandler.java
+++ b/backend/src/main/java/dev/be/dorothy/exception/HttpExceptionHandler.java
@@ -15,4 +15,12 @@ public class HttpExceptionHandler {
                 .badRequest()
                 .body(body);
     }
+
+    @ExceptionHandler(InternalServerErrorException.class)
+    public ResponseEntity<CommonResponse> handle(InternalServerErrorException e) {
+        CommonResponse body = new CommonResponse(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage(), null);
+        return ResponseEntity
+                .internalServerError()
+                .body(body);
+    }
 }

--- a/backend/src/main/java/dev/be/dorothy/exception/HttpExceptionHandler.java
+++ b/backend/src/main/java/dev/be/dorothy/exception/HttpExceptionHandler.java
@@ -1,0 +1,18 @@
+package dev.be.dorothy.exception;
+
+import dev.be.dorothy.common.CommonResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class HttpExceptionHandler {
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<CommonResponse> handle(BadRequestException e) {
+        CommonResponse body = new CommonResponse(HttpStatus.BAD_REQUEST, e.getMessage(), null);
+        return ResponseEntity
+                .badRequest()
+                .body(body);
+    }
+}

--- a/backend/src/test/java/dev/be/dorothy/exception/HttpExceptionHandlerTest.java
+++ b/backend/src/test/java/dev/be/dorothy/exception/HttpExceptionHandlerTest.java
@@ -31,4 +31,20 @@ public class HttpExceptionHandlerTest {
                 () -> assertThat(Objects.requireNonNull(response.getBody()).getMessage()).isEqualTo("이것은 배드 리퀘스트야")
         );
     }
+
+    @Test
+    @DisplayName("InternalServerError handle Test")
+    void internalServerError() {
+        // given
+        InternalServerErrorException exception = new InternalServerErrorException("서버에서 알 수 없는 에러가 발생했단말이야,,");
+
+        // when
+        ResponseEntity<CommonResponse> response = handler.handle(exception);
+
+        // then
+        assertAll(
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR),
+                () -> assertThat(Objects.requireNonNull(response.getBody()).getMessage()).isEqualTo("서버에서 알 수 없는 에러가 발생했단말이야,,")
+        );
+    }
 }

--- a/backend/src/test/java/dev/be/dorothy/exception/HttpExceptionHandlerTest.java
+++ b/backend/src/test/java/dev/be/dorothy/exception/HttpExceptionHandlerTest.java
@@ -1,0 +1,34 @@
+package dev.be.dorothy.exception;
+
+import dev.be.dorothy.common.CommonResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("HttpExceptionHandler Test")
+public class HttpExceptionHandlerTest {
+
+    HttpExceptionHandler handler = new HttpExceptionHandler();
+
+    @Test
+    @DisplayName("BadRequest handle Test")
+    void badRequest() {
+        // given
+        BadRequestException exception = new BadRequestException("이것은 배드 리퀘스트야");
+
+        // when
+        ResponseEntity<CommonResponse> response = handler.handle(exception);
+
+        // then
+        assertAll(
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST),
+                () -> assertThat(Objects.requireNonNull(response.getBody()).getMessage()).isEqualTo("이것은 배드 리퀘스트야")
+        );
+    }
+}


### PR DESCRIPTION
# What?
통합 예외 처리를 진행하는 `HttpExceptionHandler` 생성
`BadRequestException` 예외 처리 핸들러 구현
`InternalServerErrorException` 예외 처리 핸들러 구현
`HttpExceptionHandler`의 `BadRequestException`, `InternalServerError` 예외 핸들러 테스트 케이스 작성 

# Why?
서버에서 발생한 예외를 캐치하여 최종적으로 예외 처리 및 클라이언트에게 발생한 예외에 대한 정보를 제대로 전달하기 위해

# How?
`@RestControllerAdvice`를 사용하여 각 예외에 따른 핸들러 메서드를 작성하여 처리하도록 진행

This closes #28 
