### PR TITLE
로그인 기능 구현(Service)

### DIFF
--- a/backend/src/main/java/dev/be/dorothy/member/service/LoginReqDto.java
+++ b/backend/src/main/java/dev/be/dorothy/member/service/LoginReqDto.java
@@ -4,6 +4,11 @@ public class LoginReqDto {
     private String memberId;
     private String password;
 
+    public LoginReqDto(String memberId, String password) {
+        this.memberId = memberId;
+        this.password = password;
+    }
+
     public void setMemberId(String memberId) {
         this.memberId = memberId;
     }

--- a/backend/src/main/java/dev/be/dorothy/member/service/MemberServiceImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/member/service/MemberServiceImpl.java
@@ -1,5 +1,6 @@
 package dev.be.dorothy.member.service;
 
+import dev.be.dorothy.exception.BadRequestException;
 import dev.be.dorothy.exception.InternalServerErrorException;
 import dev.be.dorothy.member.Member;
 import dev.be.dorothy.member.MemberRole;
@@ -45,6 +46,10 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public MemberResDto login(LoginReqDto loginReqDto) {
-        return null;
+        Member member = memberRepository.findByMemberId(loginReqDto.getMemberId())
+                .orElseThrow(() -> new BadRequestException("입력 정보가 올바르지 않습니다."));
+        passwordEncryptor.match(loginReqDto.getPassword(), member.getPassword());
+
+        return MemberResDto.from(member);
     }
 }

--- a/backend/src/test/java/dev/be/dorothy/member/service/MemberServiceImplTest.java
+++ b/backend/src/test/java/dev/be/dorothy/member/service/MemberServiceImplTest.java
@@ -1,0 +1,59 @@
+package dev.be.dorothy.member.service;
+
+import dev.be.dorothy.exception.BadRequestException;
+import dev.be.dorothy.member.repository.MemberRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class MemberServiceImplTest {
+    @Mock
+    MemberRepository memberRepository;
+    @Mock
+    PasswordEncryptor passwordEncryptor;
+
+    @InjectMocks
+    MemberServiceImpl memberServiceImpl;
+
+    @Test
+    @DisplayName("로그인 테스트 - 실패 케이스(ID가 존재하지 않는 경우)")
+    void validateIdExists() {
+        LoginReqDto loginReqDto = new LoginReqDto("abcd1234", "a1234567!");
+
+        given(memberRepository.findByMemberId(loginReqDto.getMemberId())).willReturn(Optional.empty());
+
+        BadRequestException badRequestException =
+                assertThrows(BadRequestException.class, () ->
+                        memberServiceImpl.login(loginReqDto));
+
+        assertThat(badRequestException.getMessage()).isEqualTo("입력 정보가 올바르지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("로그인 테스트 - 실패 케이스(password가 일치하지 않는 경우)")
+    void validatePassword() {
+        LoginReqDto loginReqDto = new LoginReqDto("abcd1234", "a1234567!");
+        String hashedPassword = "45a49cbdfe0e5b676579f409c96f58759b44cfc907e78d6c2c3fe38a9c67b0cf";
+
+        lenient().doThrow(BadRequestException.class)
+                .when(passwordEncryptor)
+                .match(loginReqDto.getPassword(), hashedPassword);
+
+        BadRequestException badRequestException =
+                Assertions.assertThrows(BadRequestException.class, () ->
+                        memberServiceImpl.login(loginReqDto));
+
+        assertThat(badRequestException.getMessage()).isEqualTo("입력 정보가 올바르지 않습니다.");
+    }
+}


### PR DESCRIPTION
# What?
- 로그인 요청 데이터를 담는 LoginReqDto 클래스 작성
- 로그인 시 입력된 ID가 DB에 존재하지 않는 경우 테스트 케이스 작성
- 로그인 시 입력된 password가 DB에 저장된 password와 일치하지 않는 경우 테스트 케이스 작성
- Service 단에서 로그인 기능 구현

# Why?
- 로그인 기능의 비즈니스 로직을 처리하기 위해

# How?
- MemberRepository 클래스의 findByMemberId 메서드 활용
- PasswordEncryptor 클래스의 match 메서드 활용
- TDD 방식 적용

This closes #13
