### PR TITLE
MemberController signUp 세션 추가 부분  구현

### DIFF
--- a/backend/src/main/java/dev/be/dorothy/member/controller/MemberController.java
+++ b/backend/src/main/java/dev/be/dorothy/member/controller/MemberController.java
@@ -11,6 +11,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
 @RestController
 @RequestMapping("/member")
 public class MemberController {
@@ -22,10 +25,16 @@ public class MemberController {
     }
 
     @PostMapping("")
-    public ResponseEntity<CommonResponse> signUp(@RequestBody SignUpReqDto signUpReqDto) {
+    public ResponseEntity<CommonResponse> signUp(
+            HttpServletRequest request,
+            @RequestBody SignUpReqDto signUpReqDto
+    ) {
         MemberResDto memberResDto = memberService.signUp(signUpReqDto);
         CommonResponse commonResponse = new CommonResponse(HttpStatus.CREATED, "회원가입이 완료되었습니다.", memberResDto);
-        // TODO: 세션 등록 및 쿠키 발급
+
+        HttpSession session = request.getSession(true);
+        session.setAttribute("member", memberResDto);
+
         return new ResponseEntity<>(commonResponse, HttpStatus.CREATED);
     }
 }


### PR DESCRIPTION
# What?
MemberController signUp 세션 추가 부분  구현

# Why?
회원가입을 성공하였으면 로그인 처리를 해야하기 때문에 세션 생성 및 세션에 유저 정보를 등록해야한다.

# How?
`HttpServletRequest`의 request를 받아와 세션을 생성하고 세션에 유저 정보를 등록하는 방식으로 진행하였다.

This closes #35 
