### PR TITLE
트랙 생성 서비스 로직 구현

### DIFF
--- a/backend/src/main/java/dev/be/dorothy/exception/ForbiddenException.java
+++ b/backend/src/main/java/dev/be/dorothy/exception/ForbiddenException.java
@@ -1,0 +1,21 @@
+package dev.be.dorothy.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ForbiddenException extends RuntimeException {
+    private final HttpStatus status;
+
+    public ForbiddenException() {
+        super("권한이 존재하지 않습니다.");
+        this.status = HttpStatus.FORBIDDEN;
+    }
+
+    public ForbiddenException(String message) {
+        super(message);
+        this.status = HttpStatus.FORBIDDEN;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/backend/src/main/java/dev/be/dorothy/exception/HttpExceptionHandler.java
+++ b/backend/src/main/java/dev/be/dorothy/exception/HttpExceptionHandler.java
@@ -23,4 +23,12 @@ public class HttpExceptionHandler {
                 .internalServerError()
                 .body(body);
     }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<CommonResponse> handle(ForbiddenException e) {
+        CommonResponse body = new CommonResponse(HttpStatus.FORBIDDEN, e.getMessage(), null);
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(body);
+    }
 }

--- a/backend/src/main/java/dev/be/dorothy/track/Track.java
+++ b/backend/src/main/java/dev/be/dorothy/track/Track.java
@@ -1,6 +1,7 @@
 package dev.be.dorothy.track;
 
 import dev.be.dorothy.member.Member;
+import dev.be.dorothy.member.MemberRole;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Transient;
 import org.springframework.data.relational.core.mapping.MappedCollection;
@@ -41,6 +42,10 @@ public class Track {
 
     public void addTrackMember(Member member) {
         trackMembers.add(new TrackMember(member.getIdx(), member.getRole(), LocalDateTime.now(), false));
+    }
+
+    public void addTrackMember(Long memberIdx, MemberRole role) {
+        trackMembers.add(new TrackMember(memberIdx, role, LocalDateTime.now(), false));
     }
 
     public List<Long> getMemberIds() {

--- a/backend/src/main/java/dev/be/dorothy/track/service/TrackResDto.java
+++ b/backend/src/main/java/dev/be/dorothy/track/service/TrackResDto.java
@@ -1,7 +1,5 @@
 package dev.be.dorothy.track.service;
 
-import dev.be.dorothy.member.MemberRole;
-
 import java.time.LocalDateTime;
 
 public class TrackResDto {
@@ -10,17 +8,13 @@ public class TrackResDto {
     private final String image;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
-    private final MemberRole role;
-    private final LocalDateTime joinedAt;
 
-    public TrackResDto(Long idx, String name, String image, LocalDateTime createdAt, LocalDateTime updatedAt, MemberRole role, LocalDateTime joinedAt) {
+    public TrackResDto(Long idx, String name, String image, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.idx = idx;
         this.name = name;
         this.image = image;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
-        this.role = role;
-        this.joinedAt = joinedAt;
     }
 
     public Long getIdx() {
@@ -41,13 +35,5 @@ public class TrackResDto {
 
     public LocalDateTime getUpdatedAt() {
         return updatedAt;
-    }
-
-    public MemberRole getRole() {
-        return role;
-    }
-
-    public LocalDateTime getJoinedAt() {
-        return joinedAt;
     }
 }

--- a/backend/src/main/java/dev/be/dorothy/track/service/register/TrackRegister.java
+++ b/backend/src/main/java/dev/be/dorothy/track/service/register/TrackRegister.java
@@ -1,0 +1,8 @@
+package dev.be.dorothy.track.service.register;
+
+import dev.be.dorothy.member.MemberRole;
+import dev.be.dorothy.track.service.TrackResDto;
+
+public interface TrackRegister {
+    TrackResDto create(Long memberIdx, String name, MemberRole role);
+}

--- a/backend/src/main/java/dev/be/dorothy/track/service/register/TrackRegisterImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/track/service/register/TrackRegisterImpl.java
@@ -1,0 +1,11 @@
+package dev.be.dorothy.track.service.register;
+
+import dev.be.dorothy.member.MemberRole;
+import dev.be.dorothy.track.service.TrackResDto;
+
+public class TrackRegisterImpl implements TrackRegister {
+    @Override
+    public TrackResDto create(Long memberIdx, String name, MemberRole role) {
+        return null;
+    }
+}

--- a/backend/src/main/java/dev/be/dorothy/track/service/register/TrackRegisterImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/track/service/register/TrackRegisterImpl.java
@@ -1,11 +1,36 @@
 package dev.be.dorothy.track.service.register;
 
+import dev.be.dorothy.exception.ForbiddenException;
 import dev.be.dorothy.member.MemberRole;
+import dev.be.dorothy.track.Track;
+import dev.be.dorothy.track.repository.TrackRepository;
 import dev.be.dorothy.track.service.TrackResDto;
+import org.springframework.stereotype.Service;
 
+@Service
 public class TrackRegisterImpl implements TrackRegister {
+    private final TrackRepository trackRepository;
+
+    public TrackRegisterImpl(TrackRepository trackRepository) {
+        this.trackRepository = trackRepository;
+    }
+
     @Override
     public TrackResDto create(Long memberIdx, String name, MemberRole role) {
-        return null;
+        if (role != MemberRole.ADMIN) {
+            throw new ForbiddenException();
+        }
+
+        Track track = new Track(name, "");
+        track.addTrackMember(memberIdx, role);
+        trackRepository.save(track);
+
+        return new TrackResDto(
+                track.getIdx(),
+                track.getName(),
+                track.getImage(),
+                track.getCreatedAt(),
+                track.getUpdatedAt()
+        );
     }
 }

--- a/backend/src/test/java/dev/be/dorothy/exception/HttpExceptionHandlerTest.java
+++ b/backend/src/test/java/dev/be/dorothy/exception/HttpExceptionHandlerTest.java
@@ -47,4 +47,20 @@ public class HttpExceptionHandlerTest {
                 () -> assertThat(Objects.requireNonNull(response.getBody()).getMessage()).isEqualTo("서버에서 알 수 없는 에러가 발생했단말이야,,")
         );
     }
+
+    @Test
+    @DisplayName("Forbidden handle Test")
+    void forbidden() {
+        // given
+        ForbiddenException exception = new ForbiddenException();
+
+        // when
+        ResponseEntity<CommonResponse> response = handler.handle(exception);
+
+        // then
+        assertAll(
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN),
+                () -> assertThat(Objects.requireNonNull(response.getBody()).getMessage()).isEqualTo("권한이 존재하지 않습니다.")
+        );
+    }
 }

--- a/backend/src/test/java/dev/be/dorothy/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/dev/be/dorothy/member/controller/MemberControllerTest.java
@@ -21,7 +21,7 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest
+@WebMvcTest(controllers = MemberController.class)
 @DisplayName("MemberController Test")
 public class MemberControllerTest {
     @Autowired

--- a/backend/src/test/java/dev/be/dorothy/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/dev/be/dorothy/member/controller/MemberControllerTest.java
@@ -1,7 +1,6 @@
 package dev.be.dorothy.member.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import dev.be.dorothy.auth.AuthenticationFilter;
 import dev.be.dorothy.auth.authentication.UsernameAndPasswordTokenProvider;
 import dev.be.dorothy.exception.BadRequestException;
 import dev.be.dorothy.member.Member;
@@ -22,7 +21,7 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest({MemberController.class, UsernameAndPasswordTokenProvider.class, AuthenticationFilter.class})
+@WebMvcTest
 @DisplayName("MemberController Test")
 public class MemberControllerTest {
     @Autowired
@@ -30,6 +29,9 @@ public class MemberControllerTest {
 
     @MockBean
     MemberService memberService;
+
+    @MockBean
+    UsernameAndPasswordTokenProvider usernameAndPasswordTokenProvider;
 
     ObjectMapper objectMapper = new ObjectMapper();
 
@@ -44,7 +46,7 @@ public class MemberControllerTest {
 
         // when
         ResultActions perform = mockMvc.perform(
-                post("/member/login")
+                post("/api/v1/member/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(content));
 
@@ -67,7 +69,7 @@ public class MemberControllerTest {
 
         // when
         ResultActions perform = mockMvc.perform(
-                post("/member/login")
+                post("/api/v1/member/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(content));
 

--- a/backend/src/test/java/dev/be/dorothy/track/service/register/TrackRegisterTest.java
+++ b/backend/src/test/java/dev/be/dorothy/track/service/register/TrackRegisterTest.java
@@ -1,0 +1,54 @@
+package dev.be.dorothy.track.service.register;
+
+import dev.be.dorothy.member.Member;
+import dev.be.dorothy.member.MemberRole;
+import dev.be.dorothy.track.Track;
+import dev.be.dorothy.track.repository.TrackRepository;
+import dev.be.dorothy.track.service.TrackResDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TrackRegister Test")
+public class TrackRegisterTest {
+
+    @Mock
+    TrackRepository trackRepository;
+
+    @InjectMocks
+    TrackRegisterImpl trackRegister;
+
+    @Mock
+    Member member;
+
+    @Test
+    @DisplayName("트랙 생성 성공하여 정상적으로 TrackResDto 응답하는지 테스트")
+    void createTrack() {
+        // given
+        given(member.getIdx()).willReturn(1L);
+        given(member.getRole()).willReturn(MemberRole.MEMBER);
+
+        Track track = new Track("code-squad", "");
+        track.addTrackMember(member);
+        given(trackRepository.save(any())).willReturn(track);
+
+        // when
+        TrackResDto trackResDto = trackRegister.create(1L, "lucas", MemberRole.MEMBER);
+
+        // then
+        assertAll(
+                () -> assertThat(trackResDto.getName()).isEqualTo("code-squad"),
+                () -> assertThat(trackResDto.getRole()).isEqualTo(MemberRole.MEMBER)
+        );
+    }
+}

--- a/backend/src/test/java/dev/be/dorothy/track/service/register/TrackRegisterTest.java
+++ b/backend/src/test/java/dev/be/dorothy/track/service/register/TrackRegisterTest.java
@@ -1,54 +1,39 @@
 package dev.be.dorothy.track.service.register;
 
-import dev.be.dorothy.member.Member;
+import dev.be.dorothy.exception.ForbiddenException;
 import dev.be.dorothy.member.MemberRole;
-import dev.be.dorothy.track.Track;
-import dev.be.dorothy.track.repository.TrackRepository;
-import dev.be.dorothy.track.service.TrackResDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("TrackRegister Test")
 public class TrackRegisterTest {
 
-    @Mock
-    TrackRepository trackRepository;
-
     @InjectMocks
     TrackRegisterImpl trackRegister;
 
-    @Mock
-    Member member;
+    @Test
+    @DisplayName("권한이 운영진이 아닌 경우 (멤버인 경우) 403 예외를 던지는지 테스트")
+    void createTrackWhenMember() {
+        // given when then
+        assertThrows(
+                ForbiddenException.class,
+                () -> trackRegister.create(1L, "lucas", MemberRole.MEMBER)
+        );
+    }
 
     @Test
-    @DisplayName("트랙 생성 성공하여 정상적으로 TrackResDto 응답하는지 테스트")
-    void createTrack() {
-        // given
-        given(member.getIdx()).willReturn(1L);
-        given(member.getRole()).willReturn(MemberRole.MEMBER);
-
-        Track track = new Track("code-squad", "");
-        track.addTrackMember(member);
-        given(trackRepository.save(any())).willReturn(track);
-
-        // when
-        TrackResDto trackResDto = trackRegister.create(1L, "lucas", MemberRole.MEMBER);
-
-        // then
-        assertAll(
-                () -> assertThat(trackResDto.getName()).isEqualTo("code-squad"),
-                () -> assertThat(trackResDto.getRole()).isEqualTo(MemberRole.MEMBER)
+    @DisplayName("권한이 운영진이 아닌 경우 (슈퍼 어드민인 경우) 403 예외를 던지는지 테스트")
+    void createTrackWhenSuperAdmin() {
+        // given when then
+        assertThrows(
+                ForbiddenException.class,
+                () -> trackRegister.create(1L, "lucas", MemberRole.SUPER_ADMIN)
         );
     }
 }


### PR DESCRIPTION
# What?
- TrackRegister 구현
- 403 커스텀 예외 및 403 예외 핸들러 구현
- TrackResDto 수정

# Why?
### TrackRegister 구현
- 트랙 및 트랙 멤버 생성을 관리하는 TrackRegister 생성
- 트랙의 생성을 진행하기 위해 create 메서드 구현

### 403 커스텀 예외 및 403 예외 핸들러 구현
트랙 생성 시, ADMIN이 아닌 경우에 대한 권한 예외 처리를 진행하기 위해 ForbiddenException 및 이를 처리하는 handler 구현

### TrackResDto 수정
기존 TrackResDto는 요청자의 권한과 트랙 가입일을 포함하고 있었으나, 해당 필드가 필요하지 않다고 결정되어 제거

# How?

### TrackRegister 구현
- 트랙 및 트랙 멤버 생성을 관리하는 TrackRegister 생성
- 트랙을 생성하는 create 메서드 구현 및 테스트 테이스 작성
- 테스트 케이스는 트랙 생성에 관한 케이스를 작성하였으며, 요청자 권한이 ADMIN이 아닌 경우에 대하여 작성

### 403 커스텀 예외 및 403 예외 핸들러 구현
- ForbiddenException 커스텀 예외를 작성
- HttpExceptionHandler에서 403을 처리하는 handle 메서드 구현

This closes #47 
