### PR TITLE
트랙 참여 기능 구현

### DIFF
--- a/backend/src/main/java/dev/be/dorothy/track/service/TrackCodeManagerService.java
+++ b/backend/src/main/java/dev/be/dorothy/track/service/TrackCodeManagerService.java
@@ -1,0 +1,6 @@
+package dev.be.dorothy.track.service;
+
+public interface TrackCodeManagerService {
+    String store(); // 랜덤으로 생성된 초대 코드를 redis 에 저장한 후 반환
+    String read(String trackIdx); // trackIdx를 키 값으로 가진 초대 코드 조회
+}

--- a/backend/src/main/java/dev/be/dorothy/track/service/TrackRegisterService.java
+++ b/backend/src/main/java/dev/be/dorothy/track/service/TrackRegisterService.java
@@ -4,4 +4,5 @@ import dev.be.dorothy.member.MemberRole;
 
 public interface TrackRegisterService {
     TrackResDto create(Long memberIdx, String name, MemberRole role);
+    TrackResDto join(Long trackIdx, Long trackMemberIdx, String joinCode);
 }

--- a/backend/src/main/java/dev/be/dorothy/track/service/TrackRegisterService.java
+++ b/backend/src/main/java/dev/be/dorothy/track/service/TrackRegisterService.java
@@ -4,5 +4,5 @@ import dev.be.dorothy.member.MemberRole;
 
 public interface TrackRegisterService {
     TrackResDto create(Long memberIdx, String name, MemberRole role);
-    TrackResDto join(Long trackIdx, Long trackMemberIdx, String joinCode);
+    TrackResDto join(Long trackIdx, Long memberIdx, String joinCode);
 }

--- a/backend/src/main/java/dev/be/dorothy/track/service/TrackRegisterService.java
+++ b/backend/src/main/java/dev/be/dorothy/track/service/TrackRegisterService.java
@@ -1,0 +1,7 @@
+package dev.be.dorothy.track.service;
+
+import dev.be.dorothy.member.MemberRole;
+
+public interface TrackRegisterService {
+    TrackResDto create(Long memberIdx, String name, MemberRole role);
+}

--- a/backend/src/main/java/dev/be/dorothy/track/service/TrackRegisterServiceImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/track/service/TrackRegisterServiceImpl.java
@@ -32,4 +32,9 @@ public class TrackRegisterServiceImpl implements TrackRegisterService {
                 track.getUpdatedAt()
         );
     }
+
+    @Override
+    public TrackResDto join(Long trackIdx, Long trackMemberIdx, String joinCode) {
+        return null;
+    }
 }

--- a/backend/src/main/java/dev/be/dorothy/track/service/TrackRegisterServiceImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/track/service/TrackRegisterServiceImpl.java
@@ -7,8 +7,6 @@ import dev.be.dorothy.track.Track;
 import dev.be.dorothy.track.repository.TrackRepository;
 import org.springframework.stereotype.Service;
 
-import javax.crypto.BadPaddingException;
-
 @Service
 public class TrackRegisterServiceImpl implements TrackRegisterService {
     private final TrackCodeManagerService trackCodeManagerService;
@@ -40,6 +38,24 @@ public class TrackRegisterServiceImpl implements TrackRegisterService {
 
     @Override
     public TrackResDto join(Long trackIdx, Long memberIdx, String joinCode) {
-        return null;
+        Track track = trackRepository
+                .findById(trackIdx)
+                .orElseThrow(() -> new BadRequestException("트랙정보가 유효하지 않습니다."));
+
+        String code = trackCodeManagerService.read(trackIdx.toString());
+        if (!code.equals(joinCode)) {
+            throw new ForbiddenException();
+        }
+
+        track.addTrackMember(memberIdx, MemberRole.MEMBER);
+        trackRepository.save(track);
+
+        return new TrackResDto(
+                track.getIdx(),
+                track.getName(),
+                track.getImage(),
+                track.getCreatedAt(),
+                track.getUpdatedAt()
+        );
     }
 }

--- a/backend/src/main/java/dev/be/dorothy/track/service/TrackRegisterServiceImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/track/service/TrackRegisterServiceImpl.java
@@ -1,16 +1,21 @@
 package dev.be.dorothy.track.service;
 
+import dev.be.dorothy.exception.BadRequestException;
 import dev.be.dorothy.exception.ForbiddenException;
 import dev.be.dorothy.member.MemberRole;
 import dev.be.dorothy.track.Track;
 import dev.be.dorothy.track.repository.TrackRepository;
 import org.springframework.stereotype.Service;
 
+import javax.crypto.BadPaddingException;
+
 @Service
 public class TrackRegisterServiceImpl implements TrackRegisterService {
+    private final TrackCodeManagerService trackCodeManagerService;
     private final TrackRepository trackRepository;
 
-    public TrackRegisterServiceImpl(TrackRepository trackRepository) {
+    public TrackRegisterServiceImpl(TrackCodeManagerService trackCodeManagerService, TrackRepository trackRepository) {
+        this.trackCodeManagerService = trackCodeManagerService;
         this.trackRepository = trackRepository;
     }
 
@@ -34,7 +39,7 @@ public class TrackRegisterServiceImpl implements TrackRegisterService {
     }
 
     @Override
-    public TrackResDto join(Long trackIdx, Long trackMemberIdx, String joinCode) {
+    public TrackResDto join(Long trackIdx, Long memberIdx, String joinCode) {
         return null;
     }
 }

--- a/backend/src/main/java/dev/be/dorothy/track/service/TrackRegisterServiceImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/track/service/TrackRegisterServiceImpl.java
@@ -1,17 +1,16 @@
-package dev.be.dorothy.track.service.register;
+package dev.be.dorothy.track.service;
 
 import dev.be.dorothy.exception.ForbiddenException;
 import dev.be.dorothy.member.MemberRole;
 import dev.be.dorothy.track.Track;
 import dev.be.dorothy.track.repository.TrackRepository;
-import dev.be.dorothy.track.service.TrackResDto;
 import org.springframework.stereotype.Service;
 
 @Service
-public class TrackRegisterImpl implements TrackRegister {
+public class TrackRegisterServiceImpl implements TrackRegisterService {
     private final TrackRepository trackRepository;
 
-    public TrackRegisterImpl(TrackRepository trackRepository) {
+    public TrackRegisterServiceImpl(TrackRepository trackRepository) {
         this.trackRepository = trackRepository;
     }
 

--- a/backend/src/main/java/dev/be/dorothy/track/service/register/TrackRegister.java
+++ b/backend/src/main/java/dev/be/dorothy/track/service/register/TrackRegister.java
@@ -1,8 +1,0 @@
-package dev.be.dorothy.track.service.register;
-
-import dev.be.dorothy.member.MemberRole;
-import dev.be.dorothy.track.service.TrackResDto;
-
-public interface TrackRegister {
-    TrackResDto create(Long memberIdx, String name, MemberRole role);
-}

--- a/backend/src/test/java/dev/be/dorothy/track/service/TrackRegisterServiceTest.java
+++ b/backend/src/test/java/dev/be/dorothy/track/service/TrackRegisterServiceTest.java
@@ -1,8 +1,7 @@
-package dev.be.dorothy.track.service.register;
+package dev.be.dorothy.track.service;
 
 import dev.be.dorothy.exception.ForbiddenException;
 import dev.be.dorothy.member.MemberRole;
-import dev.be.dorothy.track.service.TrackRegisterServiceImpl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,13 +9,15 @@ import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("TrackRegisterService Test")
 public class TrackRegisterServiceTest {
 
     @InjectMocks
-    TrackRegisterServiceImpl trackRegister;
+    TrackRegisterServiceImpl trackRegisterService;
 
     @Test
     @DisplayName("권한이 운영진이 아닌 경우 (멤버인 경우) 403 예외를 던지는지 테스트")
@@ -24,7 +25,7 @@ public class TrackRegisterServiceTest {
         // given when then
         assertThrows(
                 ForbiddenException.class,
-                () -> trackRegister.create(1L, "lucas", MemberRole.MEMBER)
+                () -> trackRegisterService.create(1L, "lucas", MemberRole.MEMBER)
         );
     }
 
@@ -34,7 +35,24 @@ public class TrackRegisterServiceTest {
         // given when then
         assertThrows(
                 ForbiddenException.class,
-                () -> trackRegister.create(1L, "lucas", MemberRole.SUPER_ADMIN)
+                () -> trackRegisterService.create(1L, "lucas", MemberRole.SUPER_ADMIN)
+        );
+    }
+
+    @Test
+    @DisplayName("트랙 가입 시, 초대 코드가 일치하지 않는 경우 테스트")
+    void joinWithInvalidJoinCode() {
+        // given
+        long trackIdx = 1L;
+        long memberIdx = 99L;
+        String joinCode = "123456";
+        TrackCodeManagerService trackCodeManagerService = mock(TrackCodeManagerService.class);
+        given(trackCodeManagerService.read(Long.toString(trackIdx))).willReturn("a1b2c3");
+
+        // when then
+        assertThrows(
+                ForbiddenException.class,
+                () -> trackRegisterService.join(trackIdx, memberIdx, joinCode)
         );
     }
 }

--- a/backend/src/test/java/dev/be/dorothy/track/service/TrackRegisterServiceTest.java
+++ b/backend/src/test/java/dev/be/dorothy/track/service/TrackRegisterServiceTest.java
@@ -1,13 +1,18 @@
 package dev.be.dorothy.track.service;
 
+import dev.be.dorothy.exception.BadRequestException;
 import dev.be.dorothy.exception.ForbiddenException;
 import dev.be.dorothy.member.MemberRole;
+import dev.be.dorothy.track.repository.TrackRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -54,5 +59,23 @@ public class TrackRegisterServiceTest {
                 ForbiddenException.class,
                 () -> trackRegisterService.join(trackIdx, memberIdx, joinCode)
         );
+    }
+
+    @Test
+    @DisplayName("트랙 가입 시, 트랙이 존재하지 않는 경우")
+    void joinWhenTrackDoesNotExist() {
+        // given
+        long trackIdx = 1L;
+        TrackRepository trackRepository = mock(TrackRepository.class);
+        given(trackRepository.findById(trackIdx)).willReturn(Optional.empty());
+
+        // when
+        BadRequestException exception = assertThrows(
+                BadRequestException.class,
+                () -> trackRegisterService.join(trackIdx, 99L, "123456")
+        );
+
+        // then
+        assertThat(exception.getMessage()).isEqualTo("트랙정보가 유효하지 않습니다.");
     }
 }

--- a/backend/src/test/java/dev/be/dorothy/track/service/TrackRegisterServiceTest.java
+++ b/backend/src/test/java/dev/be/dorothy/track/service/TrackRegisterServiceTest.java
@@ -3,11 +3,13 @@ package dev.be.dorothy.track.service;
 import dev.be.dorothy.exception.BadRequestException;
 import dev.be.dorothy.exception.ForbiddenException;
 import dev.be.dorothy.member.MemberRole;
+import dev.be.dorothy.track.Track;
 import dev.be.dorothy.track.repository.TrackRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
@@ -20,6 +22,12 @@ import static org.mockito.Mockito.mock;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("TrackRegisterService Test")
 public class TrackRegisterServiceTest {
+
+    @Mock
+    TrackRepository trackRepository;
+
+    @Mock
+    TrackCodeManagerService trackCodeManagerService;
 
     @InjectMocks
     TrackRegisterServiceImpl trackRegisterService;
@@ -51,8 +59,8 @@ public class TrackRegisterServiceTest {
         long trackIdx = 1L;
         long memberIdx = 99L;
         String joinCode = "123456";
-        TrackCodeManagerService trackCodeManagerService = mock(TrackCodeManagerService.class);
-        given(trackCodeManagerService.read(Long.toString(trackIdx))).willReturn("a1b2c3");
+        given(trackRepository.findById(trackIdx)).willReturn(Optional.of(mock(Track.class)));
+        given(trackCodeManagerService.read(String.valueOf(trackIdx))).willReturn("a1b2c3");
 
         // when then
         assertThrows(
@@ -66,7 +74,6 @@ public class TrackRegisterServiceTest {
     void joinWhenTrackDoesNotExist() {
         // given
         long trackIdx = 1L;
-        TrackRepository trackRepository = mock(TrackRepository.class);
         given(trackRepository.findById(trackIdx)).willReturn(Optional.empty());
 
         // when

--- a/backend/src/test/java/dev/be/dorothy/track/service/register/TrackRegisterServiceTest.java
+++ b/backend/src/test/java/dev/be/dorothy/track/service/register/TrackRegisterServiceTest.java
@@ -2,6 +2,7 @@ package dev.be.dorothy.track.service.register;
 
 import dev.be.dorothy.exception.ForbiddenException;
 import dev.be.dorothy.member.MemberRole;
+import dev.be.dorothy.track.service.TrackRegisterServiceImpl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,11 +12,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("TrackRegister Test")
-public class TrackRegisterTest {
+@DisplayName("TrackRegisterService Test")
+public class TrackRegisterServiceTest {
 
     @InjectMocks
-    TrackRegisterImpl trackRegister;
+    TrackRegisterServiceImpl trackRegister;
 
     @Test
     @DisplayName("권한이 운영진이 아닌 경우 (멤버인 경우) 403 예외를 던지는지 테스트")


### PR DESCRIPTION
# What?
1. 트랙 참여 기능을 수행하는 `TrackRegisterServiceImpl`의 `join` 메서드 구현
2. 요청 참여 코드와 실제 트랙 참여 코드가 다른 경우에 대한 트랙 참여 예외 테스트 케이스 작성
3. 트랙이 존재하지 않는 경우에 대한 트랙 참여 예외 테스트 케이스 작성

# Why?

### 트랙 참여 기능을 수행하는 `TrackRegisterServiceImpl`의 `join` 메서드 구현
사용자가 참여 코드를 가지고 트랙에 참여할 수 있어야 하기 때문이다.

### 요청 참여 코드와 실제 트랙 참여 코드가 다른 경우에 대한 트랙 참여 예외 테스트 케이스 작성
트랙에 참여하기 위해서는 트랙 idx로 등록되어있는 참여 코드로만 참여 가능하기 때문이다.

### 트랙이 존재하지 않는 경우에 대한 트랙 참여 예외 테스트 케이스 작성
존재하지 않는 트랙에는 참여할 수 없기 때문이다.

# How?
### 트랙 참여 기능을 수행하는 `TrackRegisterServiceImpl`의 `join` 메서드 구현
1. 트랙이 존재하는지 체크하여 존재하지 않는 경우 `BadRequestException`을 던진다.
2. 요청 참여 코드와 실제 트랙의 참여코드가 일치한지 체크한 후 일치하지 않으면 `ForbiddenException` 예외를 던진다.

### 요청 참여 코드와 실제 트랙 참여 코드가 다른 경우에 대한 트랙 참여 예외 테스트 케이스 작성
`TrackCodeManager`를 mock객체로 만들고, `read`를 stub하여 반환 코드를 요청코드와 다른 코드를 반환하도록 만들어 테스트 한다.

### 트랙이 존재하지 않는 경우에 대한 트랙 참여 예외 테스트 케이스 작성
`TrackRepository`를 mock객체로 만들고, `findById`를 stub하여 트랙이 존재하지 않는 경우를 가정하여 테스트 한다.


This closes #issueNum
