### PR TITLE
Dto - Entity 간 Mapping을 위한 클래스 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -16,6 +16,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.mapstruct:mapstruct:1.4.2.Final'
+	annotationProcessor "org.mapstruct:mapstruct-processor:1.4.2.Final"
+	annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+	compileOnly 'org.projectlombok:lombok:1.18.22'
+	annotationProcessor 'org.projectlombok:lombok:1.18.22'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/backend/src/main/java/dev/be/dorothy/mapper/MemberResDtoMapper.java
+++ b/backend/src/main/java/dev/be/dorothy/mapper/MemberResDtoMapper.java
@@ -1,0 +1,18 @@
+package dev.be.dorothy.mapper;
+
+import dev.be.dorothy.member.Member;
+import dev.be.dorothy.member.service.MemberResDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring")
+public interface MemberResDtoMapper {
+
+    MemberResDtoMapper INSTANCE = Mappers.getMapper(MemberResDtoMapper.class);
+
+    @Mapping(target = "createdAt", expression = "java(member.getCreatedAt().toString())")
+    @Mapping(target = "updatedAt", expression = "java(member.getCreatedAt().toString())")
+    @Mapping(target = "role", expression = "java(member.getRole().name())")
+    MemberResDto entityToMemberResDto(Member member);
+}

--- a/backend/src/main/java/dev/be/dorothy/mapper/TrackResDtoMapper.java
+++ b/backend/src/main/java/dev/be/dorothy/mapper/TrackResDtoMapper.java
@@ -1,0 +1,15 @@
+package dev.be.dorothy.mapper;
+
+import dev.be.dorothy.track.Track;
+import dev.be.dorothy.track.service.TrackResDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring")
+public interface TrackResDtoMapper {
+
+    TrackResDtoMapper INSTANCE = Mappers.getMapper(TrackResDtoMapper.class);
+
+    TrackResDto entityToTrackResDto(Track track);
+
+}

--- a/backend/src/main/java/dev/be/dorothy/member/Member.java
+++ b/backend/src/main/java/dev/be/dorothy/member/Member.java
@@ -1,10 +1,12 @@
 package dev.be.dorothy.member;
 
+import lombok.AllArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
 
 import java.time.LocalDateTime;
 
+@AllArgsConstructor  //used only for mapstruct
 @Table("member")
 public class Member {
     @Id

--- a/backend/src/main/java/dev/be/dorothy/member/service/MemberResDto.java
+++ b/backend/src/main/java/dev/be/dorothy/member/service/MemberResDto.java
@@ -1,7 +1,5 @@
 package dev.be.dorothy.member.service;
 
-import dev.be.dorothy.member.Member;
-
 public class MemberResDto {
     private final Long idx;
     private final String memberId;
@@ -12,7 +10,7 @@ public class MemberResDto {
     private final String updatedAt;
     private final String role;
 
-    private MemberResDto(Long idx, String memberId, String name, String email, String image, String createdAt, String updatedAt, String role) {
+    public MemberResDto(Long idx, String memberId, String name, String email, String image, String createdAt, String updatedAt, String role) {
         this.idx = idx;
         this.memberId = memberId;
         this.name = name;
@@ -21,19 +19,6 @@ public class MemberResDto {
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.role = role;
-    }
-
-    public static MemberResDto from(Member member) {
-        return new MemberResDto(
-                member.getIdx(),
-                member.getMemberId(),
-                member.getName(),
-                member.getEmail(),
-                member.getImage(),
-                member.getCreatedAt().toString(),
-                member.getUpdatedAt().toString(),
-                member.getRole().name()
-        );
     }
 
     public Long getIdx() {

--- a/backend/src/main/java/dev/be/dorothy/member/service/MemberServiceImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/member/service/MemberServiceImpl.java
@@ -1,6 +1,7 @@
 package dev.be.dorothy.member.service;
 
 import dev.be.dorothy.exception.BadRequestException;
+import dev.be.dorothy.mapper.MemberResDtoMapper;
 import dev.be.dorothy.member.Member;
 import dev.be.dorothy.member.MemberRole;
 import dev.be.dorothy.member.repository.MemberRepository;
@@ -37,7 +38,7 @@ public class MemberServiceImpl implements MemberService {
         );
         member = memberRepository.save(member);
 
-        return MemberResDto.from(member);
+        return MemberResDtoMapper.INSTANCE.entityToMemberResDto(member);
     }
 
     @Override
@@ -46,6 +47,6 @@ public class MemberServiceImpl implements MemberService {
                 .orElseThrow(() -> new BadRequestException("입력 정보가 올바르지 않습니다."));
         passwordEncryptor.match(loginReqDto.getPassword(), member.getSalt(), member.getPassword());
 
-        return MemberResDto.from(member);
+        return MemberResDtoMapper.INSTANCE.entityToMemberResDto(member);
     }
 }

--- a/backend/src/main/java/dev/be/dorothy/security/authentication/AuthenticationManager.java
+++ b/backend/src/main/java/dev/be/dorothy/security/authentication/AuthenticationManager.java
@@ -1,6 +1,7 @@
 package dev.be.dorothy.security.authentication;
 
 import dev.be.dorothy.exception.BadRequestException;
+import dev.be.dorothy.mapper.MemberResDtoMapper;
 import dev.be.dorothy.member.Member;
 import dev.be.dorothy.member.repository.MemberRepository;
 import dev.be.dorothy.member.service.LoginReqDto;
@@ -22,6 +23,6 @@ public class AuthenticationManager {
         Member member = memberRepository.findByMemberId(loginReqDto.getMemberId())
                 .orElseThrow(() -> new BadRequestException("입력 정보가 올바르지 않습니다."));
         passwordEncryptor.match(loginReqDto.getPassword(), member.getSalt(), member.getPassword());
-        return MemberResDto.from(member);
+        return MemberResDtoMapper.INSTANCE.entityToMemberResDto(member);
     }
 }

--- a/backend/src/main/java/dev/be/dorothy/security/context/MemberDetail.java
+++ b/backend/src/main/java/dev/be/dorothy/security/context/MemberDetail.java
@@ -1,5 +1,6 @@
 package dev.be.dorothy.security.context;
 
+import dev.be.dorothy.mapper.MemberResDtoMapper;
 import dev.be.dorothy.member.Member;
 import dev.be.dorothy.member.service.MemberResDto;
 
@@ -12,7 +13,7 @@ public class MemberDetail {
     }
 
     public static MemberDetail from(Member member){
-        return new MemberDetail(MemberResDto.from(member));
+        return new MemberDetail(MemberResDtoMapper.INSTANCE.entityToMemberResDto(member));
     }
 
     public MemberResDto getMemberDto() {

--- a/backend/src/main/java/dev/be/dorothy/track/service/TrackRegisterServiceImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/track/service/TrackRegisterServiceImpl.java
@@ -2,6 +2,7 @@ package dev.be.dorothy.track.service;
 
 import dev.be.dorothy.exception.BadRequestException;
 import dev.be.dorothy.exception.ForbiddenException;
+import dev.be.dorothy.mapper.TrackResDtoMapper;
 import dev.be.dorothy.member.MemberRole;
 import dev.be.dorothy.track.Track;
 import dev.be.dorothy.track.repository.TrackRepository;
@@ -30,13 +31,7 @@ public class TrackRegisterServiceImpl implements TrackRegisterService {
         trackRepository.save(track);
         trackCodeManagerService.store(track.getIdx().toString());
 
-        return new TrackResDto(
-                track.getIdx(),
-                track.getName(),
-                track.getImage(),
-                track.getCreatedAt(),
-                track.getUpdatedAt()
-        );
+        return TrackResDtoMapper.INSTANCE.entityToTrackResDto(track);
     }
 
     @Override
@@ -58,12 +53,6 @@ public class TrackRegisterServiceImpl implements TrackRegisterService {
         track.addTrackMember(memberIdx, MemberRole.MEMBER);
         trackRepository.save(track);
 
-        return new TrackResDto(
-                track.getIdx(),
-                track.getName(),
-                track.getImage(),
-                track.getCreatedAt(),
-                track.getUpdatedAt()
-        );
+        return TrackResDtoMapper.INSTANCE.entityToTrackResDto(track);
     }
 }

--- a/backend/src/test/java/dev/be/dorothy/mapper/MemberResDtoMapperTest.java
+++ b/backend/src/test/java/dev/be/dorothy/mapper/MemberResDtoMapperTest.java
@@ -1,0 +1,27 @@
+package dev.be.dorothy.mapper;
+
+import dev.be.dorothy.member.Member;
+import dev.be.dorothy.member.MemberRole;
+import dev.be.dorothy.member.service.MemberResDto;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("MemberResDtoMapper Test")
+public class MemberResDtoMapperTest {
+
+    @Test
+    @DisplayName("entity - dto 간 변환 테스트")
+    void entityToDtoTest(){
+        Member member = Member.of(
+                "dorothy",
+                "abcd1234",
+                "2p7VxertGPCkNfnr",
+                "dorothy",
+                "dorothy@example.com",
+                MemberRole.MEMBER
+        );
+        MemberResDto dto = MemberResDtoMapper.INSTANCE.entityToMemberResDto(member);
+        Assertions.assertThat(dto.getName()).isEqualTo("dorothy");
+    }
+}

--- a/backend/src/test/java/dev/be/dorothy/mapper/TrackResDtoMapperTest.java
+++ b/backend/src/test/java/dev/be/dorothy/mapper/TrackResDtoMapperTest.java
@@ -1,0 +1,24 @@
+package dev.be.dorothy.mapper;
+
+import dev.be.dorothy.member.Member;
+import dev.be.dorothy.member.MemberRole;
+import dev.be.dorothy.member.service.MemberResDto;
+import dev.be.dorothy.track.Track;
+import dev.be.dorothy.track.service.TrackResDto;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("TrackResDtoMapper test")
+public class TrackResDtoMapperTest {
+    @Test
+    @DisplayName("entity - dto 간 변환 테스트")
+    void entityToDtoTest(){
+        Track track = new Track(
+                "hyundai",
+                ""
+        );
+        TrackResDto dto = TrackResDtoMapper.INSTANCE.entityToTrackResDto(track);
+        Assertions.assertThat(dto.getName()).isEqualTo("hyundai");
+    }
+}

--- a/backend/src/test/java/dev/be/dorothy/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/dev/be/dorothy/member/controller/MemberControllerTest.java
@@ -1,6 +1,7 @@
 package dev.be.dorothy.member.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.be.dorothy.mapper.MemberResDtoMapper;
 import dev.be.dorothy.security.filter.AuthenticationFilter;
 import dev.be.dorothy.security.filter.AuthorizationFilter;
 import dev.be.dorothy.security.filter.LoginFilter;
@@ -8,7 +9,6 @@ import dev.be.dorothy.exception.BadRequestException;
 import dev.be.dorothy.member.Member;
 import dev.be.dorothy.member.MemberRole;
 import dev.be.dorothy.member.service.LoginReqDto;
-import dev.be.dorothy.member.service.MemberResDto;
 import dev.be.dorothy.member.service.MemberService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -44,7 +44,7 @@ public class MemberControllerTest {
         LoginReqDto loginReqDto = new LoginReqDto("sol", "1234");
         String content = objectMapper.writeValueAsString(loginReqDto);
         Member member = Member.of("sol", "1234", "2p7VxertGPCkNfnr", "sol", "", MemberRole.MEMBER);
-        given(memberService.login(loginReqDto)).willReturn(MemberResDto.from(member));
+        given(memberService.login(loginReqDto)).willReturn(MemberResDtoMapper.INSTANCE.entityToMemberResDto(member));
 
         // when
         ResultActions perform = mockMvc.perform(


### PR DESCRIPTION
# What?
Mapstruct 라이브러리를 사용하여 dto-entity 간 변환을 가능케 하는 인터페이스 구현
이에 따른 정적 팩토리 메소드 삭제

# Why?
from 메소드를 사용할 경우 한 객체에서 다른 하나의 구현체에 의존하게 될 가능성이 생겨
이를 추상화한 클래스의 메소드를 사용하도록 하여 클래스의 분리를 강화

# How?
build.gradle에 lombok과 mapstrcut 의존성 추가
mapper 패키지에 Track-TrackResDto 간 변환을 담당하는 TrackResDtoMapper / member-MemberResDto 간 변환을 담당하는 MemberResDto를 생성하고 @componentModel을 통해 스프링 빈으로서 등록한 후 인터페이스 메소드로 변환 메소드를 등록
caller 측에서는 인터페이스에 정의된 INSTANCE를 가져와서 해당 메소드에 접근할 수 있도록 구현

This closes #62 