### PR TITLE
Notice 도메인 작성 및 레포지토리 구현

### DIFF
--- a/backend/src/main/java/dev/be/dorothy/notice/Notice.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/Notice.java
@@ -1,6 +1,7 @@
 package dev.be.dorothy.notice;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
@@ -10,6 +11,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Table("notice")
 public class Notice {
     @Id

--- a/backend/src/main/java/dev/be/dorothy/notice/Notice.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/Notice.java
@@ -22,7 +22,7 @@ public class Notice {
     private LocalDateTime updatedAt;
     private boolean isDeleted;
 
-    public Notice(String title, String content) {
+    private Notice(String title, String content) {
         this.title = title;
         this.content = content;
         this.createdAt = LocalDateTime.now();

--- a/backend/src/main/java/dev/be/dorothy/notice/Notice.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/Notice.java
@@ -1,0 +1,34 @@
+package dev.be.dorothy.notice;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table("notice")
+public class Notice {
+    @Id
+    private Long idx;
+    private String title;
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private boolean isDeleted;
+
+    public Notice(String title, String content) {
+        this.title = title;
+        this.content = content;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+        this.isDeleted = false;
+    }
+
+    public static Notice of(String title, String content) {
+        return new Notice(title, content);
+    }
+}

--- a/backend/src/main/java/dev/be/dorothy/notice/repository/CustomNoticeRepository.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/repository/CustomNoticeRepository.java
@@ -1,0 +1,9 @@
+package dev.be.dorothy.notice.repository;
+
+import dev.be.dorothy.notice.Notice;
+
+import java.util.Optional;
+
+public interface CustomNoticeRepository {
+    Optional<Notice> findOne(Long noticeId);
+}

--- a/backend/src/main/java/dev/be/dorothy/notice/repository/NoticeRepository.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/repository/NoticeRepository.java
@@ -1,0 +1,7 @@
+package dev.be.dorothy.notice.repository;
+
+import dev.be.dorothy.notice.Notice;
+import org.springframework.data.repository.CrudRepository;
+
+public interface NoticeRepository extends CrudRepository<Notice, Long>, CustomNoticeRepository {
+}

--- a/backend/src/main/java/dev/be/dorothy/notice/repository/NoticeRepositoryImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/repository/NoticeRepositoryImpl.java
@@ -1,0 +1,37 @@
+package dev.be.dorothy.notice.repository;
+
+import dev.be.dorothy.notice.Notice;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.EmptyResultDataAccessException;
+
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
+
+import javax.annotation.PostConstruct;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class NoticeRepositoryImpl implements CustomNoticeRepository {
+    private final NamedParameterJdbcOperations operations;
+    private RowMapper<Notice> rowMapper;
+
+    @PostConstruct
+    void initRowMapper() {
+        this.rowMapper = new NoticeRowMapper();
+    }
+
+    private static final String ALL_FIELD = "idx, title, content, created_at, updated_at, is_deleted ";
+
+    @Override
+    public Optional<Notice> findOne(Long noticeId) {
+        String sql = "SELECT " + ALL_FIELD + " FROM notice WHERE idx=:noticeId LIMIT 1";
+        MapSqlParameterSource params = new MapSqlParameterSource("noticeId", noticeId);
+        try {
+            Notice notice = operations.queryForObject(sql, params, rowMapper);
+            return Optional.ofNullable(notice);
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/backend/src/main/java/dev/be/dorothy/notice/repository/NoticeRowMapper.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/repository/NoticeRowMapper.java
@@ -1,0 +1,21 @@
+package dev.be.dorothy.notice.repository;
+
+import dev.be.dorothy.notice.Notice;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class NoticeRowMapper implements RowMapper<Notice> {
+    @Override
+    public Notice mapRow(ResultSet rs, int rowNum) throws SQLException {
+        return new Notice(
+                Long.valueOf(rs.getString("idx")),
+                rs.getString("title"),
+                rs.getString("content"),
+                rs.getTimestamp("created_at").toLocalDateTime(),
+                rs.getTimestamp("updated_at").toLocalDateTime(),
+                Boolean.parseBoolean(rs.getString("is_deleted"))
+        );
+    }
+}

--- a/backend/src/test/java/dev/be/dorothy/notice/repository/NoticeRepositoryTest.java
+++ b/backend/src/test/java/dev/be/dorothy/notice/repository/NoticeRepositoryTest.java
@@ -1,0 +1,44 @@
+package dev.be.dorothy.notice.repository;
+
+import dev.be.dorothy.notice.Notice;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.test.annotation.Rollback;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DataJdbcTest
+@AutoConfigureTestDatabase(replace= AutoConfigureTestDatabase.Replace.NONE)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("NoticeRepository Test")
+public class NoticeRepositoryTest {
+
+    @Autowired
+    NoticeRepository noticeRepository;
+
+    @Test
+    @Rollback(value = false)
+    @DisplayName("findOne 정상 조회 테스트")
+    void findOne() {
+        // given
+        Notice noticeOfHyundai = Notice.of("현대차그룹 채용 결과 안내", "all pass");
+        noticeRepository.save(noticeOfHyundai);
+        // when
+        Optional<Notice> optionalNotice = noticeRepository.findOne(noticeOfHyundai.getIdx());
+
+        // then
+        assertThat(optionalNotice.isPresent()).isTrue();
+        Notice notice = optionalNotice.get();
+        assertAll(
+                () -> assertThat(notice.getTitle()).isEqualTo("현대차그룹 채용 결과 안내"),
+                () -> assertThat(notice.getContent()).isEqualTo("all pass")
+        );
+    }
+}


### PR DESCRIPTION
# What?
## Notice 도메인 작성
- `Notice` 엔티티 작성
## Notice 레포지토리 구현
- `NoticeRepository` 인터페이스 작성
- `CustomNoticeRepository` 인터페이스 작성
- `NoticeRepositoryImpl` 클래스 작성
- `RowMapper<Notice>` 클레스 작성

# Why?
사용자에게 공지사항 기능을 구현하기 위해 기본적인 설계 및 조회 기능을 가지는 `repository` 레이어가 필요하기 때문에

# How?
## Notice 도메인 작성
기본적으로 Notice 도메인이 가지는 필드를 가지며 단순 getter를 가지는 엔티티 작성

## Notice 레포지토리 구현
- 커스텀 쿼리를 사용하기 위해 `NoticeRepository` 인터페이스를 구현하는  `NoticeRepositoryImpl` 구현
- `NoticeRepository`는 `CrudRepository<Notice, Long>`와 `CustomNoticeRepository` 인터페이스를 상속받는다.
- 커스텀 쿼리 결과로 `Notice` 객체를 만들기 위한 `RowMapper<Notice>` 작성
This closes #95
