### PR TITLE
출석 기능 관련 설계 및 위치 기반으로 출석 가능한지 확인하는 기능 담당하는 AttendanceManagerService 구현

### DIFF
--- a/backend/src/main/java/dev/be/dorothy/attendance/Attendance.java
+++ b/backend/src/main/java/dev/be/dorothy/attendance/Attendance.java
@@ -18,8 +18,7 @@ public class Attendance {
     public Attendance() {
     }
 
-    public Attendance(Long idx, Long trackMemberIdx, LocalDate date, LocalTime time, AttendanceType type) {
-        this.idx = idx;
+    public Attendance(Long trackMemberIdx, LocalDate date, LocalTime time, AttendanceType type) {
         this.trackMemberIdx = trackMemberIdx;
         this.date = date;
         this.time = time;

--- a/backend/src/main/java/dev/be/dorothy/attendance/Attendance.java
+++ b/backend/src/main/java/dev/be/dorothy/attendance/Attendance.java
@@ -1,0 +1,48 @@
+package dev.be.dorothy.attendance;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Table("attendance")
+public class Attendance {
+    @Id
+    private Long idx;
+    private Long trackMemberIdx;
+    private LocalDate date;
+    private LocalTime time;
+    private AttendanceType type;
+
+    public Attendance() {
+    }
+
+    public Attendance(Long idx, Long trackMemberIdx, LocalDate date, LocalTime time, AttendanceType type) {
+        this.idx = idx;
+        this.trackMemberIdx = trackMemberIdx;
+        this.date = date;
+        this.time = time;
+        this.type = type;
+    }
+
+    public Long getIdx() {
+        return idx;
+    }
+
+    public Long getTrackMemberIdx() {
+        return trackMemberIdx;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public LocalTime getTime() {
+        return time;
+    }
+
+    public AttendanceType getType() {
+        return type;
+    }
+}

--- a/backend/src/main/java/dev/be/dorothy/attendance/AttendanceType.java
+++ b/backend/src/main/java/dev/be/dorothy/attendance/AttendanceType.java
@@ -1,0 +1,7 @@
+package dev.be.dorothy.attendance;
+
+public enum AttendanceType {
+    PRESENT,
+    TARDY,
+    ABSENT
+}

--- a/backend/src/main/java/dev/be/dorothy/attendance/controller/AttendanceController.java
+++ b/backend/src/main/java/dev/be/dorothy/attendance/controller/AttendanceController.java
@@ -1,0 +1,4 @@
+package dev.be.dorothy.attendance.controller;
+
+public class AttendanceController {
+}

--- a/backend/src/main/java/dev/be/dorothy/attendance/repository/AttendanceRepository.java
+++ b/backend/src/main/java/dev/be/dorothy/attendance/repository/AttendanceRepository.java
@@ -1,0 +1,7 @@
+package dev.be.dorothy.attendance.repository;
+
+import dev.be.dorothy.attendance.Attendance;
+import org.springframework.data.repository.CrudRepository;
+
+public interface AttendanceRepository extends CrudRepository<Attendance, Long> {
+}

--- a/backend/src/main/java/dev/be/dorothy/attendance/service/AttendanceManagerService.java
+++ b/backend/src/main/java/dev/be/dorothy/attendance/service/AttendanceManagerService.java
@@ -1,0 +1,5 @@
+package dev.be.dorothy.attendance.service;
+
+public interface AttendanceManagerService {
+    boolean checkAttendance(Long trackIdx, Double x, Double y); // 좌표 계산을 통해 출석이 가능한지 확인
+}

--- a/backend/src/main/java/dev/be/dorothy/attendance/service/AttendanceManagerServiceImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/attendance/service/AttendanceManagerServiceImpl.java
@@ -1,0 +1,42 @@
+package dev.be.dorothy.attendance.service;
+
+import dev.be.dorothy.track.Track;
+import dev.be.dorothy.track.service.TrackRetrieveService;
+import org.springframework.data.geo.Point;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AttendanceManagerServiceImpl implements AttendanceManagerService {
+    private final TrackRetrieveService trackRetrieveService;
+
+    public AttendanceManagerServiceImpl(TrackRetrieveService trackRetrieveService) {
+        this.trackRetrieveService = trackRetrieveService;
+    }
+
+    @Override
+    public boolean checkAttendance(Long trackIdx, Double x, Double y) {
+        Point trackPoint = getTrackPoint(trackIdx);
+        Point memberPoint = new Point(x, y);
+
+        Double distance = calculateDistance(trackPoint, memberPoint);
+
+        return distance < 10;
+    }
+
+    private Point getTrackPoint(Long trackIdx) {
+        Track track = trackRetrieveService.getTrack(trackIdx);
+
+        return new Point(track.getLocation());
+    }
+
+    private Double calculateDistance(Point trackPoint, Point memberPoint) {
+        double dX = Math.toRadians(trackPoint.getX() - memberPoint.getX());
+        double dY = Math.toRadians(trackPoint.getY() - memberPoint.getY());
+
+        double a = Math.sin(dX / 2) * Math.sin(dX / 2) +
+                Math.cos(Math.toRadians(trackPoint.getX())) * Math.cos(Math.toRadians(memberPoint.getX())) *
+                        Math.sin(dY / 2) * Math.sin(dY / 2);
+        double b = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return 6371 * b * 1000; // 단위: m, Earth Radius: 약 6371km
+    }
+}

--- a/backend/src/main/java/dev/be/dorothy/attendance/service/AttendanceManagerServiceImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/attendance/service/AttendanceManagerServiceImpl.java
@@ -20,7 +20,7 @@ public class AttendanceManagerServiceImpl implements AttendanceManagerService {
 
         Double distance = calculateDistance(trackPoint, memberPoint);
 
-        return distance < 10;
+        return distance < 30;
     }
 
     private Point getTrackPoint(Long trackIdx) {
@@ -30,6 +30,7 @@ public class AttendanceManagerServiceImpl implements AttendanceManagerService {
     }
 
     private Double calculateDistance(Point trackPoint, Point memberPoint) {
+        int EARTH_RADIUS = 6371;
         double dX = Math.toRadians(trackPoint.getX() - memberPoint.getX());
         double dY = Math.toRadians(trackPoint.getY() - memberPoint.getY());
 
@@ -37,6 +38,7 @@ public class AttendanceManagerServiceImpl implements AttendanceManagerService {
                 Math.cos(Math.toRadians(trackPoint.getX())) * Math.cos(Math.toRadians(memberPoint.getX())) *
                         Math.sin(dY / 2) * Math.sin(dY / 2);
         double b = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-        return 6371 * b * 1000; // 단위: m, Earth Radius: 약 6371km
+
+        return EARTH_RADIUS * b * 1000; // 단위: m
     }
 }

--- a/backend/src/main/java/dev/be/dorothy/attendance/service/AttendanceResDto.java
+++ b/backend/src/main/java/dev/be/dorothy/attendance/service/AttendanceResDto.java
@@ -1,0 +1,30 @@
+package dev.be.dorothy.attendance.service;
+
+import dev.be.dorothy.attendance.AttendanceType;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public class AttendanceResDto {
+    private final LocalDate date;
+    private final LocalTime time;
+    private final AttendanceType type;
+
+    public AttendanceResDto(LocalDate date, LocalTime time, AttendanceType type) {
+        this.date = date;
+        this.time = time;
+        this.type = type;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public LocalTime getTime() {
+        return time;
+    }
+
+    public AttendanceType getType() {
+        return type;
+    }
+}

--- a/backend/src/main/java/dev/be/dorothy/track/TrackMember.java
+++ b/backend/src/main/java/dev/be/dorothy/track/TrackMember.java
@@ -1,12 +1,15 @@
 package dev.be.dorothy.track;
 
 import dev.be.dorothy.member.MemberRole;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
 
 import java.time.LocalDateTime;
 
 @Table("track_member")
 public class TrackMember {
+    @Id
+    private Long idx;
     private Long memberIdx;
     private Long trackIdx;
     private MemberRole role;
@@ -21,6 +24,10 @@ public class TrackMember {
         this.role = role;
         this.joinedAt = joinedAt;
         this.isDeleted = isDeleted;
+    }
+
+    public Long getIdx() {
+        return idx;
     }
 
     public Long getMemberIdx() {

--- a/backend/src/main/java/dev/be/dorothy/track/repository/TrackRepository.java
+++ b/backend/src/main/java/dev/be/dorothy/track/repository/TrackRepository.java
@@ -15,8 +15,8 @@ public interface TrackRepository extends CrudRepository<Track, Long> {
     @Query("select a.idx, a.name, a.image, a.created_at, a.updated_at from track a inner join track_member b on a.idx = b.track_idx where b.is_deleted = 0 and a.is_deleted = 0 and b.member_idx = :userIdx")
     List<TrackResDto> findByMemberId(@Param("userIdx") Long idx);
 
-    @Query("select idx from track_member where member_idx = :memberIdx and track_idx = :trackIdx limit 1")
-    Optional<Long> doesExistTrackMember(@Param("memberIdx") Long memberIdx, @Param("trackIdx") Long trackIdx);
+    @Query("select idx from track_member where member_idx = :memberIdx and track_idx = :trackIdx and is_deleted = 0 limit 1")
+    Optional<Long> getTrackMemberIdx(@Param("memberIdx") Long memberIdx, @Param("trackIdx") Long trackIdx);
 
     @Modifying
     @Query("insert into track_member values(null, :memberIdx, :trackIdx, :role, :joinedAt, :isDeleted);")

--- a/backend/src/main/java/dev/be/dorothy/track/service/TrackRegisterServiceImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/track/service/TrackRegisterServiceImpl.java
@@ -47,7 +47,7 @@ public class TrackRegisterServiceImpl implements TrackRegisterService {
                 .findById(trackIdx)
                 .orElseThrow(() -> new BadRequestException("트랙정보가 유효하지 않습니다."));
 
-        Optional<Long> trackMemberIdx = trackRepository.doesExistTrackMember(memberIdx, trackIdx);
+        Optional<Long> trackMemberIdx = trackRepository.getTrackMemberIdx(memberIdx, trackIdx);
         if(trackMemberIdx.isPresent()) {
             throw new BadRequestException("이미 존재하는 멤버입니다.");
         }

--- a/backend/src/main/java/dev/be/dorothy/track/service/TrackRetrieveService.java
+++ b/backend/src/main/java/dev/be/dorothy/track/service/TrackRetrieveService.java
@@ -1,8 +1,10 @@
 package dev.be.dorothy.track.service;
 
+import dev.be.dorothy.track.Track;
+
 import java.util.List;
 
 public interface TrackRetrieveService {
-
     List<TrackResDto> retrieveTracks(Long userIdx);
+    Track getTrack(Long trackIdx);
 }

--- a/backend/src/main/java/dev/be/dorothy/track/service/TrackRetrieveServiceImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/track/service/TrackRetrieveServiceImpl.java
@@ -1,5 +1,7 @@
 package dev.be.dorothy.track.service;
 
+import dev.be.dorothy.exception.BadRequestException;
+import dev.be.dorothy.track.Track;
 import dev.be.dorothy.track.repository.TrackRepository;
 import org.springframework.stereotype.Service;
 
@@ -16,7 +18,13 @@ public class TrackRetrieveServiceImpl implements TrackRetrieveService{
 
     @Override
     public List<TrackResDto> retrieveTracks(Long userIdx) {
-        List<TrackResDto> trackList = trackRepository.findByMemberId(userIdx);
-        return trackList;
+        return trackRepository.findByMemberId(userIdx);
+    }
+
+    @Override
+    public Track getTrack(Long trackIdx) {
+        return trackRepository
+                .findById(trackIdx)
+                .orElseThrow(() -> new BadRequestException("존재하지 않는 트랙입니다."));
     }
 }

--- a/backend/src/test/java/dev/be/dorothy/attendance/service/AttendanceManagerServiceImplTest.java
+++ b/backend/src/test/java/dev/be/dorothy/attendance/service/AttendanceManagerServiceImplTest.java
@@ -27,9 +27,9 @@ public class AttendanceManagerServiceImplTest {
                 "hyundai",
                 ""
         );
-        // 약 8m
+        // 약 26m
         double x = 37.490847;
-        double y = 127.033301;
+        double y = 127.033101;
 
         given(trackRetrieveService.getTrack(track.getIdx())).willReturn(track);
 
@@ -43,9 +43,9 @@ public class AttendanceManagerServiceImplTest {
                 "hyundai",
                 ""
         );
-        // 약 13m
+        // 약 33m
         double x = 37.490847;
-        double y = 127.033251;
+        double y = 127.033021;
 
         given(trackRetrieveService.getTrack(track.getIdx())).willReturn(track);
 

--- a/backend/src/test/java/dev/be/dorothy/attendance/service/AttendanceManagerServiceImplTest.java
+++ b/backend/src/test/java/dev/be/dorothy/attendance/service/AttendanceManagerServiceImplTest.java
@@ -1,0 +1,54 @@
+package dev.be.dorothy.attendance.service;
+
+import dev.be.dorothy.track.Track;
+import dev.be.dorothy.track.service.TrackRetrieveService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class AttendanceManagerServiceImplTest {
+    @Mock
+    TrackRetrieveService trackRetrieveService;
+
+    @InjectMocks
+    AttendanceManagerServiceImpl attendanceManagerServiceImpl;
+
+    @Test
+    @DisplayName("거리 기반 출석 확인 테스트 - 출석 성공 케이스")
+    void checkAttendanceSuccessTest() {
+        Track track = new Track(
+                "hyundai",
+                ""
+        );
+        // 약 8m
+        double x = 37.490847;
+        double y = 127.033301;
+
+        given(trackRetrieveService.getTrack(track.getIdx())).willReturn(track);
+
+        assertThat(attendanceManagerServiceImpl.checkAttendance(track.getIdx(), x, y)).isTrue();
+    }
+
+    @Test
+    @DisplayName("거리 기반 출석 확인 테스트 - 출석 실패 케이스")
+    void checkAttendanceFailTest() {
+        Track track = new Track(
+                "hyundai",
+                ""
+        );
+        // 약 13m
+        double x = 37.490847;
+        double y = 127.033251;
+
+        given(trackRetrieveService.getTrack(track.getIdx())).willReturn(track);
+
+        assertThat(attendanceManagerServiceImpl.checkAttendance(track.getIdx(), x, y)).isFalse();
+    }
+}

--- a/backend/src/test/java/dev/be/dorothy/track/repository/TrackRepositoryTest.java
+++ b/backend/src/test/java/dev/be/dorothy/track/repository/TrackRepositoryTest.java
@@ -76,7 +76,7 @@ public class TrackRepositoryTest {
         List<TrackResDto> trackResList = trackRepository.findByMemberId(memberIdx);
         Long trackIdx = trackResList.get(0).getIdx();
 
-        Optional<Long> idx = trackRepository.doesExistTrackMember(memberIdx, trackIdx);
+        Optional<Long> idx = trackRepository.getTrackMemberIdx(memberIdx, trackIdx);
 
         assertThat(idx.isPresent()).isTrue();
     }
@@ -89,7 +89,7 @@ public class TrackRepositoryTest {
         List<TrackResDto> trackResList = trackRepository.findByMemberId(memberIdx);
         Long trackIdx = trackResList.get(0).getIdx();
 
-        Optional<Long> idx = trackRepository.doesExistTrackMember(999L, trackIdx);
+        Optional<Long> idx = trackRepository.getTrackMemberIdx(999L, trackIdx);
 
         assertThat(idx.isPresent()).isFalse();
     }

--- a/backend/src/test/java/dev/be/dorothy/track/service/TrackRegisterServiceTest.java
+++ b/backend/src/test/java/dev/be/dorothy/track/service/TrackRegisterServiceTest.java
@@ -93,7 +93,7 @@ public class TrackRegisterServiceTest {
         long memberIdx = 1L;
         long trackIdx = 1L;
         given(trackRepository.findById(trackIdx)).willReturn(Optional.of(mock(Track.class)));
-        given(trackRepository.doesExistTrackMember(memberIdx, trackIdx)).willReturn(Optional.of(1L));
+        given(trackRepository.getTrackMemberIdx(memberIdx, trackIdx)).willReturn(Optional.of(1L));
 
         // when
         BadRequestException exception = assertThrows(

--- a/backend/src/test/resources/init.sql
+++ b/backend/src/test/resources/init.sql
@@ -71,8 +71,8 @@ CREATE TABLE IF NOT EXISTS `attendance`
 (
     `idx`              int         NOT NULL auto_increment primary key,
     `track_member_idx` int         NOT NULL,
-    `date`             datetime    NOT NULL DEFAULT current_timestamp,
-    `time`             time        NOT NULL,
+    `date`             date    NOT NULL,
+    `time`             time    NOT NULL,
     `type`             varchar(50) NOT NULL COMMENT 'PRESENT, TARDY, ABSENT'
 );
 


### PR DESCRIPTION
# What?
## 출석 기능 관련 설계
- init.sql 수정된 erd에 맞게 수정
- Attendance 출석 도메인 클래스 생성 및 구현
- 출결 상태 관리하는 AttendanceType enum class 구현
- AttendanceRepository 생성
- AttendanceController 생성
- AttendanceResDto 생성 및 구현
## AttendanceManagerService 구현
- TrackRepository의 doesExistTrackMember -> getTrackMemberIdx 메서드명 변경
- TrackRetrieveService에 getTrack 메서드 구현
- AttendanceManagerServiceImplTest 테스트 코드 작성
- AttendanceManagerService의 checkAttendance 메서드 구현

# Why?
## 출석 기능 관련 설계
위치 기반 출석 기능 구현하기 전에 설계하기 위해
## AttendanceManagerService 구현
- TrackMember의 PK를 받아오는 기능이므로 doesExistTrackMember 보다는 getTrackMemberIdx 가 더 올바른 메서드명이라고 판단
- trackIdx에 해당하는 Track 객체를 받아오기 위해
- 위치 기반으로 출석이 가능한지 확인하기 위해(현재 기준 10m)

# How?
## 출석 기능 관련 설계
출석 관련 API에서 응답하는 경우, 출석 날짜, 출석 시간, 출석 상태라는 데이터로 응답하도록 구현
## AttendanceManagerService 구현
- 위도, 경도 좌표를 기준으로 계산

This closes #93
This closes #98
