### PR TITLE
공지사항 조회 기능 구현 (조회수 기능 미포함)

### DIFF
--- a/backend/src/main/java/dev/be/dorothy/notice/repository/CustomNoticeRepository.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/repository/CustomNoticeRepository.java
@@ -2,8 +2,10 @@ package dev.be.dorothy.notice.repository;
 
 import dev.be.dorothy.notice.Notice;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CustomNoticeRepository {
     Optional<Notice> findOne(Long noticeId);
+    List<Notice> findAll(boolean orderByCreatedAtDesc);
 }

--- a/backend/src/main/java/dev/be/dorothy/notice/repository/NoticeRepositoryImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/repository/NoticeRepositoryImpl.java
@@ -9,6 +9,7 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 
 import javax.annotation.PostConstruct;
+import java.util.List;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -22,16 +23,28 @@ public class NoticeRepositoryImpl implements CustomNoticeRepository {
     }
 
     private static final String ALL_FIELD = "idx, title, content, created_at, updated_at, is_deleted ";
+    private static final String DEFAULT_SELECT = "SELECT " + ALL_FIELD + " FROM notice";
 
     @Override
     public Optional<Notice> findOne(Long noticeId) {
-        String sql = "SELECT " + ALL_FIELD + " FROM notice WHERE idx=:noticeId LIMIT 1";
+        String sql = DEFAULT_SELECT + " WHERE idx=:noticeId LIMIT 1";
         MapSqlParameterSource params = new MapSqlParameterSource("noticeId", noticeId);
         try {
             Notice notice = operations.queryForObject(sql, params, rowMapper);
             return Optional.ofNullable(notice);
         } catch (EmptyResultDataAccessException e) {
             return Optional.empty();
+        }
+    }
+
+    @Override
+    public List<Notice> findAll(boolean orderByCreatedAtDesc) {
+        String sort = orderByCreatedAtDesc ? "DESC" : "ASC";
+        String sql = DEFAULT_SELECT + " ORDER BY created_at " + sort;
+        try {
+            return operations.query(sql, rowMapper);
+        } catch (EmptyResultDataAccessException e) {
+            return List.of();
         }
     }
 }

--- a/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeReadService.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeReadService.java
@@ -1,0 +1,8 @@
+package dev.be.dorothy.notice.serivce;
+
+import java.util.List;
+
+public interface NoticeReadService {
+    NoticeResDto getNotice(Long noticeId);
+    List<NoticeResDto> getNotices();
+}

--- a/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeReadServiceImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeReadServiceImpl.java
@@ -1,0 +1,15 @@
+package dev.be.dorothy.notice.serivce;
+
+import java.util.List;
+
+public class NoticeReadServiceImpl implements NoticeReadService {
+    @Override
+    public NoticeResDto getNotice(Long noticeId) {
+        return null;
+    }
+
+    @Override
+    public List<NoticeResDto> getNotices() {
+        return null;
+    }
+}

--- a/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeReadServiceImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeReadServiceImpl.java
@@ -1,11 +1,26 @@
 package dev.be.dorothy.notice.serivce;
 
+import dev.be.dorothy.exception.BadRequestException;
+import dev.be.dorothy.notice.Notice;
+import dev.be.dorothy.notice.repository.NoticeRepository;
+import org.springframework.stereotype.Service;
+
 import java.util.List;
 
+@Service
 public class NoticeReadServiceImpl implements NoticeReadService {
+    private final NoticeRepository noticeRepository;
+
+    public NoticeReadServiceImpl(NoticeRepository noticeRepository) {
+        this.noticeRepository = noticeRepository;
+    }
+
     @Override
     public NoticeResDto getNotice(Long noticeId) {
-        return null;
+        Notice notice = noticeRepository.findOne(noticeId)
+                .orElseThrow(() -> new BadRequestException("해당 공지사항이 존재하지 않습니다."));
+        // TODO: 현재 views 관련 기능 구현 전
+        return NoticeResDto.of(notice.getIdx(), notice.getTitle(), notice.getContent(), notice.getCreatedAt(), 0L);
     }
 
     @Override

--- a/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeReadServiceImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeReadServiceImpl.java
@@ -5,6 +5,7 @@ import dev.be.dorothy.notice.Notice;
 import dev.be.dorothy.notice.repository.NoticeRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -25,6 +26,17 @@ public class NoticeReadServiceImpl implements NoticeReadService {
 
     @Override
     public List<NoticeResDto> getNotices() {
-        return null;
+        List<Notice> notices = noticeRepository.findAll(true);
+
+        List<NoticeResDto> noticeResDtos = new ArrayList<>();
+        // TODO: 현재 views 관련 기능 구현 전
+        for (Notice notice: notices) {
+            NoticeResDto noticeResDto = NoticeResDto.of(
+                    notice.getIdx(), notice.getTitle(), notice.getContent(), notice.getCreatedAt(), 0L
+            );
+            noticeResDtos.add(noticeResDto);
+        }
+
+        return noticeResDtos;
     }
 }

--- a/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeResDto.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeResDto.java
@@ -2,9 +2,11 @@ package dev.be.dorothy.notice.serivce;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+@Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class NoticeResDto {
     private final String title;

--- a/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeResDto.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeResDto.java
@@ -9,12 +9,13 @@ import java.time.LocalDateTime;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class NoticeResDto {
+    private final Long idx;
     private final String title;
     private final String content;
     private final LocalDateTime createdAt;
     private final Long views;
 
-    public static NoticeResDto of(String title, String content, LocalDateTime createdAt, Long views) {
-        return new NoticeResDto(title, content, createdAt, views);
+    public static NoticeResDto of(Long idx, String title, String content, LocalDateTime createdAt, Long views) {
+        return new NoticeResDto(idx, title, content, createdAt, views);
     }
 }

--- a/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeResDto.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeResDto.java
@@ -1,0 +1,18 @@
+package dev.be.dorothy.notice.serivce;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class NoticeResDto {
+    private final String title;
+    private final String content;
+    private final LocalDateTime createdAt;
+    private final Long views;
+
+    public static NoticeResDto of(String title, String content, LocalDateTime createdAt, Long views) {
+        return new NoticeResDto(title, content, createdAt, views);
+    }
+}

--- a/backend/src/test/java/dev/be/dorothy/notice/repository/NoticeRepositoryTest.java
+++ b/backend/src/test/java/dev/be/dorothy/notice/repository/NoticeRepositoryTest.java
@@ -7,8 +7,9 @@ import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.test.annotation.Rollback;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,7 +25,6 @@ public class NoticeRepositoryTest {
     NoticeRepository noticeRepository;
 
     @Test
-    @Rollback(value = false)
     @DisplayName("findOne 정상 조회 테스트")
     void findOne() {
         // given
@@ -39,6 +39,41 @@ public class NoticeRepositoryTest {
         assertAll(
                 () -> assertThat(notice.getTitle()).isEqualTo("현대차그룹 채용 결과 안내"),
                 () -> assertThat(notice.getContent()).isEqualTo("all pass")
+        );
+    }
+
+    @Test
+    @DisplayName("findAll ORDER BY ASC 정상 조회 테스트")
+    void findAllWithOrderByAsc() {
+        // given
+        Notice noticeOfHyundai = new Notice(null, "현대차그룹 채용 결과 안내", "all pass", LocalDateTime.now().minusDays(1), LocalDateTime.now().minusDays(1), false);
+        Notice noticeOfCodeSquad = new Notice(null, "코드스쿼드 수료 결과 안내", "all pass", LocalDateTime.now(), LocalDateTime.now(), false);
+        noticeRepository.saveAll(List.of(noticeOfHyundai, noticeOfCodeSquad));
+        // when
+        List<Notice> notices = noticeRepository.findAll(false);
+
+        // then
+        assertAll(
+                () -> assertThat(notices.size()).isEqualTo(2),
+                () -> assertThat(notices.get(0).getTitle()).isEqualTo("현대차그룹 채용 결과 안내")
+        );
+    }
+
+    @Test
+    @DisplayName("findAll ORDER BY DESC 정상 조회 테스트")
+    void findAllWithOrderByDesc() {
+        // given
+        Notice noticeOfHyundai = new Notice(null, "현대차그룹 채용 결과 안내", "all pass", LocalDateTime.now().minusDays(1), LocalDateTime.now().minusDays(1), false);
+        Notice noticeOfCodeSquad = new Notice(null, "코드스쿼드 수료 결과 안내", "all pass", LocalDateTime.now(), LocalDateTime.now(), false);
+        noticeRepository.saveAll(List.of(noticeOfHyundai, noticeOfCodeSquad));
+
+        // when
+        List<Notice> notices = noticeRepository.findAll(true);
+
+        // then
+        assertAll(
+                () -> assertThat(notices.size()).isEqualTo(2),
+                () -> assertThat(notices.get(0).getTitle()).isEqualTo("코드스쿼드 수료 결과 안내")
         );
     }
 }

--- a/backend/src/test/java/dev/be/dorothy/notice/service/NoticeReadServiceTest.java
+++ b/backend/src/test/java/dev/be/dorothy/notice/service/NoticeReadServiceTest.java
@@ -1,0 +1,64 @@
+package dev.be.dorothy.notice.service;
+
+import dev.be.dorothy.exception.BadRequestException;
+import dev.be.dorothy.notice.Notice;
+import dev.be.dorothy.notice.repository.NoticeRepository;
+import dev.be.dorothy.notice.serivce.NoticeReadServiceImpl;
+import dev.be.dorothy.notice.serivce.NoticeResDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+@DisplayName("NoticeReadService Test")
+@ExtendWith(MockitoExtension.class)
+public class NoticeReadServiceTest {
+    @Mock
+    NoticeRepository noticeRepository;
+
+    @InjectMocks
+    NoticeReadServiceImpl noticeReadService;
+
+    @Test
+    @DisplayName("Notice 단일 조회 시, 디비에서 조회한 Notice를 정상적으로 NoticeResDto로 반환하는지 테스트")
+    void getNotice() {
+        // given
+        Long noticeId = 1L;
+        Notice notice = new Notice(noticeId, "현대차그룹 채용결과 안내", "all pass", LocalDateTime.now(), LocalDateTime.now(), false);
+        given(noticeRepository.findOne(noticeId)).willReturn(Optional.of(notice));
+
+        // when
+        NoticeResDto noticeResDto = noticeReadService.getNotice(noticeId);
+
+        // then
+        assertAll(
+                () -> assertThat(noticeResDto.getIdx()).isEqualTo(noticeId),
+                () -> assertThat(noticeResDto.getTitle()).isEqualTo("현대차그룹 채용결과 안내")
+        );
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 Notice ID로 조회 요청 시, 400 BAD REQUEST 예외를 던지는지 테스트")
+    void getNoticeWithInvalidNoticeId() {
+        // given
+        Long noticeId = 1L;
+        given(noticeRepository.findOne(noticeId)).willReturn(Optional.empty());
+
+        // when then
+        BadRequestException exception = assertThrows(
+                BadRequestException.class,
+                () -> noticeReadService.getNotice(noticeId)
+        );
+        assertThat(exception.getMessage()).isEqualTo("해당 공지사항이 존재하지 않습니다.");
+    }
+}


### PR DESCRIPTION
# What?
### `NoticeReadService` `getNotice`, `getNotices` 메서드 구현
### `NoticeRepository` `findAll` 메서드 구현

# Why?
### `NoticeReadService` `getNotice`, `getNotices` 메서드 구현
- 사용자의 공지사항 조회 요청을 처리하기 위해 단일 조회와 전체 조회 메서드를 구현

### `NoticeRepository` `findAll` 메서드 구현
`NoticeReadService`가 공지사항에 대한 데이터를 필요로 하기 때문에 `NoticeRepository`에 실제 디비에서 공지사항을 조회하는 메서드 구현

# How?
### `NoticeReadService` `getNotice`, `getNotices` 메서드 구현
- `getNotice`의 경우 `noticeId`를 받는데, `NoticeRepositry`의 조회 결과에 따라 `NoticeResDto`를 응답하거나 `400 Bad Request`
 예외를 던진다.
- `getNotices`의 경우 디비에 존재하는 모든 공지사항을 조회하며, `Order By created_at` 조건으로 내림 차순 정렬을 조회를 통해 처리한다.
    - 만약, 공지사항이 존재하지 않다면, 비어있는 `List<NoticeResDto>`를 응답한다.
    - 현재는 페이징을 지원하지 않는다.
 
### `NoticeRepository` `findAll` 메서드 구현
- 실제 데이터베이스에 존재하는 모든 공지사항을 조회하도록 기본적은 `SELECT `쿼리를 만들어 사용
- 메서드 파라미터로 `orderByCreatedAtDesc`를 `boolean`으로 받아 정렬 조건을 설정한다.

# 추가 이슈로 진행할 기능
공지사항의 조회수 기능은 동시성 처리에 대하여 좀 더 고민후 새로운 이슈로 개발 진행 예정

---

This closes #96 