### PR TITLE
동시성 제어를 위한 Redis distributed lock 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation group: 'org.testcontainers', name: 'testcontainers', version: '1.17.2'
 }
 
 tasks.named('test') {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -17,6 +17,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.mapstruct:mapstruct:1.4.2.Final'
+	implementation 'org.redisson:redisson-spring-boot-starter:3.17.7'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	annotationProcessor "org.mapstruct:mapstruct-processor:1.4.2.Final"
 	annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
 	compileOnly 'org.projectlombok:lombok:1.18.22'

--- a/backend/src/main/java/dev/be/dorothy/aspect/AopForTransaction.java
+++ b/backend/src/main/java/dev/be/dorothy/aspect/AopForTransaction.java
@@ -1,0 +1,16 @@
+package dev.be.dorothy.aspect;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class AopForTransaction {
+
+    //AOP 내의 트랜잭션을 생성하기 위하여 생성, 부모 트랜잭션의 유무와는 별도로 새 트랙잭션 생성
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/backend/src/main/java/dev/be/dorothy/aspect/DistributedLockAop.java
+++ b/backend/src/main/java/dev/be/dorothy/aspect/DistributedLockAop.java
@@ -1,0 +1,55 @@
+package dev.be.dorothy.aspect;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Aspect
+@Component
+@Slf4j
+public class DistributedLockAop {
+
+    private final RedissonClient redissonClient;
+    private final AopForTransaction aopForTransaction;
+    @Value("${spring.redis.prefix}")
+    private String prefix;
+
+    public DistributedLockAop(RedissonClient redissonClient, AopForTransaction aopForTransaction) {
+        this.redissonClient = redissonClient;
+        this.aopForTransaction = aopForTransaction;
+    }
+
+    @Around("@annotation(dev.be.dorothy.aspect.EnableLock)")
+    public Object lock(final ProceedingJoinPoint joinPoint) throws InterruptedException {
+        //Aspect의 대상 메소드와 애노테이션에 대한 정보를 획득
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        EnableLock distributeLock = method.getAnnotation(EnableLock.class);
+
+        String key = prefix + RedissonKeyParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), distributeLock.key());
+        RLock rLock = redissonClient.getLock(key);
+
+        try {
+            //lock 획득 시도
+            boolean available = rLock.tryLock(distributeLock.waitTime(), distributeLock.occupyTime(), distributeLock.timeUnit());
+            if (!available) {
+                return false;
+            }
+            log.info("get lock success {}" , key);
+            return aopForTransaction.proceed(joinPoint);  //메소드 호출
+        } catch (Throwable e) {
+            Thread.currentThread().interrupt();
+            throw new InterruptedException();
+        } finally {
+            rLock.unlock();  //lock 반환
+        }
+    }
+}

--- a/backend/src/main/java/dev/be/dorothy/aspect/EnableLock.java
+++ b/backend/src/main/java/dev/be/dorothy/aspect/EnableLock.java
@@ -1,0 +1,21 @@
+package dev.be.dorothy.aspect;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+/**
+ *  annotation for distributed lock using Redisson Client
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EnableLock {
+
+    String key(); //name of lock
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+    long waitTime() default 5L;
+    long occupyTime() default 3L;
+
+}

--- a/backend/src/main/java/dev/be/dorothy/aspect/RedissonKeyParser.java
+++ b/backend/src/main/java/dev/be/dorothy/aspect/RedissonKeyParser.java
@@ -1,0 +1,21 @@
+package dev.be.dorothy.aspect;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+/**
+ * SpelExpression으로 전달된 key값을 파싱하기 위한 클래스
+ */
+public class RedissonKeyParser {
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/backend/src/main/java/dev/be/dorothy/reservation/Reservation.java
+++ b/backend/src/main/java/dev/be/dorothy/reservation/Reservation.java
@@ -1,0 +1,58 @@
+package dev.be.dorothy.reservation;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+
+@Table("reservation")
+public class Reservation {
+
+    @Id
+    private Long idx;
+    private final Long memberIdx;
+    private final Long placeIdx;
+    private final LocalDateTime date;
+    private final LocalTime startTime;
+    private final LocalTime endTime;
+    private final boolean isDeleted;
+
+    public Reservation(Long memberIdx, Long placeIdx, LocalTime startTime) {
+        this.memberIdx = memberIdx;
+        this.placeIdx = placeIdx;
+        this.date = LocalDateTime.now();
+        this.startTime = startTime;
+        this.endTime = startTime.plusMinutes(15);
+        this.isDeleted = false;
+    }
+
+    public Long getIdx() {
+        return idx;
+    }
+
+    public Long getMemberIdx() {
+        return memberIdx;
+    }
+
+    public Long getPlaceIdx() {
+        return placeIdx;
+    }
+
+    public LocalDateTime getDate() {
+        return date;
+    }
+
+    public LocalTime getStartTime() {
+        return startTime;
+    }
+
+    public LocalTime getEndTime() {
+        return endTime;
+    }
+
+    public boolean isDeleted() {
+        return isDeleted;
+    }
+}

--- a/backend/src/main/java/dev/be/dorothy/reservation/controller/PlaceController.java
+++ b/backend/src/main/java/dev/be/dorothy/reservation/controller/PlaceController.java
@@ -2,12 +2,17 @@ package dev.be.dorothy.reservation.controller;
 
 import dev.be.dorothy.common.CommonResponse;
 import dev.be.dorothy.reservation.service.PlaceResDto;
+import dev.be.dorothy.reservation.service.PlaceReservationServiceImpl;
 import dev.be.dorothy.reservation.service.PlaceService;
 
+import dev.be.dorothy.reservation.service.ReservationResDto;
+import dev.be.dorothy.security.context.ContextHolder;
+import dev.be.dorothy.security.context.MemberDetail;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalTime;
 import java.util.List;
 
 @RestController
@@ -15,9 +20,11 @@ import java.util.List;
 public class PlaceController {
 
     private final PlaceService placeService;
+    private final PlaceReservationServiceImpl placeReservationService;
 
-    public PlaceController(PlaceService placeService) {
+    public PlaceController(PlaceService placeService, PlaceReservationServiceImpl placeReservationService) {
         this.placeService = placeService;
+        this.placeReservationService = placeReservationService;
     }
 
     @PostMapping("")
@@ -32,6 +39,16 @@ public class PlaceController {
         List<PlaceResDto> placeList = placeService.retrievePlaces();
         CommonResponse commonResponse = new CommonResponse(HttpStatus.OK, "공간 조회에 성공하였습니다.", placeList);
         return new ResponseEntity<>(commonResponse, HttpStatus.OK);
+    }
+
+    @PostMapping("/reservation/{placeIdx}")
+    public ResponseEntity<CommonResponse> applyPlace(
+            @PathVariable Long placeIdx,
+            @RequestParam("time") LocalTime startTime){
+        MemberDetail memberDetail = (MemberDetail) ContextHolder.getContext().getPrincipal();
+        ReservationResDto appliedPlace = placeReservationService.reservePlace(memberDetail.getMemberDto().getIdx(),placeIdx, startTime);
+        CommonResponse commonResponse = new CommonResponse(HttpStatus.OK, "공간 대여 신청이 완료되었습니다.", appliedPlace);
+        return new ResponseEntity<>(commonResponse, HttpStatus.CREATED);
     }
 
 }

--- a/backend/src/main/java/dev/be/dorothy/reservation/controller/PlaceController.java
+++ b/backend/src/main/java/dev/be/dorothy/reservation/controller/PlaceController.java
@@ -8,6 +8,7 @@ import dev.be.dorothy.reservation.service.PlaceService;
 import dev.be.dorothy.reservation.service.ReservationResDto;
 import dev.be.dorothy.security.context.ContextHolder;
 import dev.be.dorothy.security.context.MemberDetail;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -27,6 +28,13 @@ public class PlaceController {
         this.placeReservationService = placeReservationService;
     }
 
+    @GetMapping("")
+    public ResponseEntity<CommonResponse> placeList(){
+        List<PlaceResDto> placeList = placeService.retrievePlaces();
+        CommonResponse commonResponse = new CommonResponse(HttpStatus.OK, "공간 조회에 성공하였습니다.", placeList);
+        return new ResponseEntity<>(commonResponse, HttpStatus.OK);
+    }
+
     @PostMapping("")
     public ResponseEntity<CommonResponse> placeAdd(@RequestParam("name") String name){
         PlaceResDto newPlace = placeService.addPlace(name);
@@ -34,17 +42,10 @@ public class PlaceController {
         return new ResponseEntity<>(commonResponse, HttpStatus.CREATED);
     }
 
-    @GetMapping("/list")
-    public ResponseEntity<CommonResponse> placeList(){
-        List<PlaceResDto> placeList = placeService.retrievePlaces();
-        CommonResponse commonResponse = new CommonResponse(HttpStatus.OK, "공간 조회에 성공하였습니다.", placeList);
-        return new ResponseEntity<>(commonResponse, HttpStatus.OK);
-    }
-
     @PostMapping("/reservation/{placeIdx}")
     public ResponseEntity<CommonResponse> applyPlace(
             @PathVariable Long placeIdx,
-            @RequestParam("time") LocalTime startTime){
+            @RequestParam("time") @DateTimeFormat(iso = DateTimeFormat.ISO.TIME) LocalTime startTime){
         MemberDetail memberDetail = (MemberDetail) ContextHolder.getContext().getPrincipal();
         ReservationResDto appliedPlace = placeReservationService.reservePlace(memberDetail.getMemberDto().getIdx(),placeIdx, startTime);
         CommonResponse commonResponse = new CommonResponse(HttpStatus.OK, "공간 대여 신청이 완료되었습니다.", appliedPlace);

--- a/backend/src/main/java/dev/be/dorothy/reservation/repository/PlaceRepository.java
+++ b/backend/src/main/java/dev/be/dorothy/reservation/repository/PlaceRepository.java
@@ -20,6 +20,9 @@ public interface PlaceRepository extends CrudRepository<Place, Long> {
     @Query("select idx, start_time, end_time from reservation where idx = :idx")
     Optional<ReservationResDto> findReservationById(@Param("idx") Integer idx);
 
+    @Query("select idx, start_time, end_time from reservation")
+    List<ReservationResDto> findAllReservations();
+
     @Modifying
     @Query("insert into reservation (member_idx, place_idx, date, start_time, end_time, is_deleted) values (:memberIdx, :placeIdx, :date, :startTime, :endTime, :isDeleted)")
     Integer reservePlace(
@@ -29,4 +32,8 @@ public interface PlaceRepository extends CrudRepository<Place, Long> {
             @Param("startTime") LocalTime startTime,
             @Param("endTime") LocalTime endTime,
             @Param("isDeleted") boolean isDeleted);
+
+    @Modifying
+    @Query("delete from reservation")
+    void deleteAllReservation();
 }

--- a/backend/src/main/java/dev/be/dorothy/reservation/repository/PlaceRepository.java
+++ b/backend/src/main/java/dev/be/dorothy/reservation/repository/PlaceRepository.java
@@ -2,13 +2,31 @@ package dev.be.dorothy.reservation.repository;
 
 import dev.be.dorothy.reservation.Place;
 import dev.be.dorothy.reservation.service.PlaceResDto;
+import dev.be.dorothy.reservation.service.ReservationResDto;
+import org.springframework.data.jdbc.repository.query.Modifying;
 import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.CrudRepository;
-
+import org.springframework.data.repository.query.Param;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface PlaceRepository extends CrudRepository<Place, Long> {
 
     @Query("select idx, name, image, created_at, updated_at from place")
     List<PlaceResDto> findAllPlaces();
+
+    @Query("select idx, start_time, end_time from reservation where idx = :idx")
+    Optional<ReservationResDto> findReservationById(@Param("idx") Integer idx);
+
+    @Modifying
+    @Query("insert into reservation (member_idx, place_idx, date, start_time, end_time, is_deleted) values (:memberIdx, :placeIdx, :date, :startTime, :endTime, :isDeleted)")
+    Integer reservePlace(
+            @Param("memberIdx") Long memberIdx,
+            @Param("placeIdx")Long placeIdx,
+            @Param("date") LocalDateTime date,
+            @Param("startTime") LocalTime startTime,
+            @Param("endTime") LocalTime endTime,
+            @Param("isDeleted") boolean isDeleted);
 }

--- a/backend/src/main/java/dev/be/dorothy/reservation/service/PlaceReservationManager.java
+++ b/backend/src/main/java/dev/be/dorothy/reservation/service/PlaceReservationManager.java
@@ -1,0 +1,5 @@
+package dev.be.dorothy.reservation.service;
+
+public interface PlaceReservationManager {
+    boolean reservePlace(String key, Long memberIdx);
+}

--- a/backend/src/main/java/dev/be/dorothy/reservation/service/PlaceReservationManagerImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/reservation/service/PlaceReservationManagerImpl.java
@@ -16,8 +16,9 @@ public class PlaceReservationManagerImpl implements PlaceReservationManager{
     @EnableLock(key = "#key")  //Distructed Lock을 획득하기 위한 Aspect를 호출
     public boolean reservePlace(String key, Long memberIdx) {
         Optional<String> values = Optional.ofNullable(redisDao.getValues(key));
-        if(values.isPresent())
+        if(values.isPresent()){
             return false;
+        }
         redisDao.setValues(key, String.valueOf(memberIdx));
         return true;
     }

--- a/backend/src/main/java/dev/be/dorothy/reservation/service/PlaceReservationManagerImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/reservation/service/PlaceReservationManagerImpl.java
@@ -1,0 +1,24 @@
+package dev.be.dorothy.reservation.service;
+
+import dev.be.dorothy.aspect.EnableLock;
+import dev.be.dorothy.redis.RedisDao;
+import org.springframework.stereotype.Service;
+import java.util.Optional;
+
+@Service
+public class PlaceReservationManagerImpl implements PlaceReservationManager{
+    private final RedisDao redisDao;
+
+    public PlaceReservationManagerImpl(RedisDao redisDao) {
+        this.redisDao = redisDao;
+    }
+
+    @EnableLock(key = "#key")  //Distructed Lock을 획득하기 위한 Aspect를 호출
+    public boolean reservePlace(String key, Long memberIdx) {
+        Optional<String> values = Optional.ofNullable(redisDao.getValues(key));
+        if(values.isPresent())
+            return false;
+        redisDao.setValues(key, String.valueOf(memberIdx));
+        return true;
+    }
+}

--- a/backend/src/main/java/dev/be/dorothy/reservation/service/PlaceReservationService.java
+++ b/backend/src/main/java/dev/be/dorothy/reservation/service/PlaceReservationService.java
@@ -1,0 +1,9 @@
+package dev.be.dorothy.reservation.service;
+
+import java.time.LocalTime;
+
+public interface PlaceReservationService {
+
+    ReservationResDto reservePlace(Long memberIdx, Long placeIdx, LocalTime startTime);
+
+}

--- a/backend/src/main/java/dev/be/dorothy/reservation/service/PlaceReservationServiceImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/reservation/service/PlaceReservationServiceImpl.java
@@ -1,0 +1,23 @@
+package dev.be.dorothy.reservation.service;
+
+import dev.be.dorothy.exception.BadRequestException;
+import dev.be.dorothy.reservation.repository.PlaceRepository;
+import org.springframework.stereotype.Service;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Service
+public class PlaceReservationServiceImpl implements PlaceReservationService{
+
+    private final PlaceRepository placeRepository;
+    public PlaceReservationServiceImpl(PlaceRepository placeRepository) {
+        this.placeRepository = placeRepository;
+    }
+
+    @Override
+    public ReservationResDto reservePlace(Long memberIdx, Long placeIdx, LocalTime startTime) {
+        //TODO : 날짜와 시작 시간의 형식은 향후 수정할 예정
+        Integer reservationID = placeRepository.reservePlace(memberIdx, placeIdx, LocalDateTime.now(), startTime, startTime.plusMinutes(15), false);
+        return placeRepository.findReservationById(reservationID).orElseThrow(() -> new BadRequestException("입력 정보가 올바르지 않습니다."));
+    }
+}

--- a/backend/src/main/java/dev/be/dorothy/reservation/service/PlaceReservationServiceImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/reservation/service/PlaceReservationServiceImpl.java
@@ -10,14 +10,26 @@ import java.time.LocalTime;
 public class PlaceReservationServiceImpl implements PlaceReservationService{
 
     private final PlaceRepository placeRepository;
-    public PlaceReservationServiceImpl(PlaceRepository placeRepository) {
+    private final PlaceReservationManagerImpl placeReservationManagerImpl;
+    private static final String RESERVATION_KEY = "RESERVATION_";
+
+    public PlaceReservationServiceImpl(PlaceRepository placeRepository, PlaceReservationManagerImpl placeReservationManagerImpl) {
         this.placeRepository = placeRepository;
+        this.placeReservationManagerImpl = placeReservationManagerImpl;
     }
 
     @Override
     public ReservationResDto reservePlace(Long memberIdx, Long placeIdx, LocalTime startTime) {
-        //TODO : 날짜와 시작 시간의 형식은 향후 수정할 예정
+        StringBuilder keyBuilder = new StringBuilder();
+        keyBuilder.append(RESERVATION_KEY)
+                .append(placeIdx)
+                .append("-")
+                .append(startTime);
+        if(!placeReservationManagerImpl.reservePlace(keyBuilder.toString(), memberIdx)){
+            throw new BadRequestException("이미 예약된 공간입니다.");
+        }
         Integer reservationID = placeRepository.reservePlace(memberIdx, placeIdx, LocalDateTime.now(), startTime, startTime.plusMinutes(15), false);
         return placeRepository.findReservationById(reservationID).orElseThrow(() -> new BadRequestException("입력 정보가 올바르지 않습니다."));
     }
+
 }

--- a/backend/src/main/java/dev/be/dorothy/reservation/service/ReservationResDto.java
+++ b/backend/src/main/java/dev/be/dorothy/reservation/service/ReservationResDto.java
@@ -1,0 +1,28 @@
+package dev.be.dorothy.reservation.service;
+
+import java.time.LocalTime;
+
+public class ReservationResDto {
+
+    private final Long idx;
+    private final LocalTime startTime;
+    private final LocalTime endTime;
+
+    public ReservationResDto(Long idx, LocalTime startTime, LocalTime endTime) {
+        this.idx = idx;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public Long getIdx() {
+        return idx;
+    }
+
+    public LocalTime getStartTime() {
+        return startTime;
+    }
+
+    public LocalTime getEndTime() {
+        return endTime;
+    }
+}

--- a/backend/src/test/java/dev/be/dorothy/redis/RedisTestContainer.java
+++ b/backend/src/test/java/dev/be/dorothy/redis/RedisTestContainer.java
@@ -1,0 +1,26 @@
+package dev.be.dorothy.redis;
+
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.context.annotation.Configuration;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@Configuration
+@DisplayName("Redis Test Container")
+public class RedisTestContainer {
+
+    private static final String REDIS_IMAGE = "redis:5.0.3-alpine";
+
+    static {
+        GenericContainer<?> REDIS_CONTAINER =
+                new GenericContainer<>(DockerImageName.parse(REDIS_IMAGE))
+                        .withExposedPorts(6379)
+                        .withReuse(true);
+
+        REDIS_CONTAINER.start();
+
+        System.setProperty("spring.redis.host", REDIS_CONTAINER.getHost());
+        System.setProperty("spring.redis.port", REDIS_CONTAINER.getMappedPort(6379).toString());
+    }
+
+}

--- a/backend/src/test/java/dev/be/dorothy/reservation/repository/PlaceRepositoryTest.java
+++ b/backend/src/test/java/dev/be/dorothy/reservation/repository/PlaceRepositoryTest.java
@@ -1,14 +1,24 @@
 package dev.be.dorothy.reservation.repository;
 
+import dev.be.dorothy.member.Member;
+import dev.be.dorothy.member.MemberRole;
+import dev.be.dorothy.member.repository.MemberRepository;
 import dev.be.dorothy.reservation.Place;
 import dev.be.dorothy.reservation.service.PlaceResDto;
+import dev.be.dorothy.reservation.service.ReservationResDto;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJdbcTest
 @AutoConfigureTestDatabase(replace= AutoConfigureTestDatabase.Replace.NONE)
@@ -17,7 +27,10 @@ class PlaceRepositoryTest {
 
     @Autowired
     PlaceRepository placeRepository;
-    
+
+    @Autowired
+    MemberRepository memberRepository;
+
     @Test
     @DisplayName("공간 등록 기능 테스트")
     void placeRegisterTest(){
@@ -42,5 +55,36 @@ class PlaceRepositoryTest {
         //then
         Assertions.assertThat(allPlaces).hasSize(2);
     }
+
+    @Test
+    @DisplayName("공간 예약 신청 테스트 - 동시성 배제")
+    void reservePlaceTest(){
+
+        //given
+        Member member = Member.of(
+                "dorothy",
+                "abcd1234",
+                "2p7VxertGPCkNfnr",
+                "dorothy",
+                "dorothy@example.com",
+                MemberRole.MEMBER
+        );
+        memberRepository.save(member);
+
+        Place place = new Place("place1", "");
+        placeRepository.save(place);
+
+        //when
+        int reservationId = placeRepository.reservePlace(
+                member.getIdx(),
+                place.getIdx(),
+                LocalDateTime.now(),
+                LocalTime.now(),
+                LocalTime.now().plusMinutes(15),
+                false);
+
+        //then
+        Optional<ReservationResDto> reservation = placeRepository.findReservationById(reservationId);
+        assertThat(reservation).isNotNull();}
 
 }


### PR DESCRIPTION
# What?
공유 자원에 대한 여러 쓰레드의 동시 요청에 대응할 수 있는 distributed lock 구현
Aspect를 이용하여 동시성 처리를 요하는 특정 메소드의 실행 이전에 lock 획득 로직을 삽입
@EnableLock 이라는 커스텀 애노테이션을 생성하여 lock 획득에 필요한 key, timeUnit, leaseTime, waitTime에 대한 정보를 수록
이를 통하여 공간 예약 메소드에 동시성 제어 로직을 추가하였음 
RedisTestContainer를 통하여 테스트 시만 작동하는 레디스 컨테이너를 생성

# Why?
여러 사용자가 동시 다발적으로 한 자원에 대하여 요청을 보낼 때 스프링의 transactional 어노테이션으로는 모든 요청을 효과적으로 대응할 수 없음. 그렇기에 Redis라는 in-memory database를 통하여 critical section에 접근하기 위한 로직의 처리 속도를 높이고, redis에서 lock을 얻고 예약을 요청하는 로직과 실제 db에 예약 사항을 insert하는 로직을 별도의 transaction으로 분리하여 효율성 향상 및 동시성 관리를 도모

# How?
Redis의 Redisson client의 의존성을 추가하여 distributed lock 구현
distributed lock을 획득할 경우, PlaceReservationManager의 reservePlace라는 메소드를 실행하여 기존의 redis에 ["RESERVATION_{place_idx}_{start_time} : {memberIdx}] 의 형식으로 저장.
 

This closes #114
