### PR TITLE
공지사항 생성 기능 구현

### DIFF
--- a/backend/src/main/java/dev/be/dorothy/notice/Notice.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/Notice.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 public class Notice {
     @Id
     private Long idx;
+    private Long memberIdx;
     private String title;
     private String content;
     private LocalDateTime createdAt;
@@ -23,8 +24,9 @@ public class Notice {
     private Long views;
     private boolean isDeleted;
 
-    private Notice(String title, String content) {
+    private Notice(Long memberIdx, String title, String content) {
         this.title = title;
+        this.memberIdx = memberIdx;
         this.content = content;
         this.views = 0L;
         this.createdAt = LocalDateTime.now();
@@ -32,7 +34,7 @@ public class Notice {
         this.isDeleted = false;
     }
 
-    public static Notice of(String title, String content) {
-        return new Notice(title, content);
+    public static Notice of(Long memberIdx, String title, String content) {
+        return new Notice(memberIdx, title, content);
     }
 }

--- a/backend/src/main/java/dev/be/dorothy/notice/Notice.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/Notice.java
@@ -20,11 +20,13 @@ public class Notice {
     private String content;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private Long views;
     private boolean isDeleted;
 
     private Notice(String title, String content) {
         this.title = title;
         this.content = content;
+        this.views = 0L;
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
         this.isDeleted = false;

--- a/backend/src/main/java/dev/be/dorothy/notice/controller/NoticeController.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/controller/NoticeController.java
@@ -1,0 +1,43 @@
+package dev.be.dorothy.notice.controller;
+
+import dev.be.dorothy.common.CommonResponse;
+import dev.be.dorothy.exception.ForbiddenException;
+import dev.be.dorothy.member.MemberRole;
+import dev.be.dorothy.notice.serivce.NoticeCreateDto;
+import dev.be.dorothy.notice.serivce.NoticeCreateService;
+import dev.be.dorothy.notice.serivce.NoticeResDto;
+import dev.be.dorothy.security.context.ContextHolder;
+import dev.be.dorothy.security.context.MemberDetail;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notice")
+public class NoticeController {
+    private final NoticeCreateService noticeCreateService;
+
+    public NoticeController(NoticeCreateService noticeCreateService) {
+        this.noticeCreateService = noticeCreateService;
+    }
+
+    @PostMapping("")
+    public ResponseEntity<CommonResponse> create(
+            @RequestBody NoticeCreateDto noticeCreateDto
+    ) {
+        MemberRole role = MemberRole.valueOf(ContextHolder.getContext().getRole().toString());
+        if (role != MemberRole.ADMIN) {
+            throw new ForbiddenException("권한이 존재하지 않습니다.");
+        }
+
+        MemberDetail principal = (MemberDetail) ContextHolder.getContext().getPrincipal();
+
+        NoticeResDto noticeResDto = noticeCreateService.create(principal.getMemberDto().getIdx(), noticeCreateDto);
+        CommonResponse response = new CommonResponse(HttpStatus.CREATED, "공지사항을 정상적으로 생성하였습니다.", noticeResDto);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+}

--- a/backend/src/main/java/dev/be/dorothy/notice/repository/NoticeRepositoryImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/repository/NoticeRepositoryImpl.java
@@ -22,7 +22,7 @@ public class NoticeRepositoryImpl implements CustomNoticeRepository {
         this.rowMapper = new NoticeRowMapper();
     }
 
-    private static final String ALL_FIELD = "idx, title, content, views, created_at, updated_at, is_deleted ";
+    private static final String ALL_FIELD = "idx, member_idx, title, content, views, created_at, updated_at, is_deleted ";
     private static final String DEFAULT_SELECT = "SELECT " + ALL_FIELD + " FROM notice";
 
     @Override

--- a/backend/src/main/java/dev/be/dorothy/notice/repository/NoticeRepositoryImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/repository/NoticeRepositoryImpl.java
@@ -22,7 +22,7 @@ public class NoticeRepositoryImpl implements CustomNoticeRepository {
         this.rowMapper = new NoticeRowMapper();
     }
 
-    private static final String ALL_FIELD = "idx, title, content, created_at, updated_at, is_deleted ";
+    private static final String ALL_FIELD = "idx, title, content, views, created_at, updated_at, is_deleted ";
     private static final String DEFAULT_SELECT = "SELECT " + ALL_FIELD + " FROM notice";
 
     @Override

--- a/backend/src/main/java/dev/be/dorothy/notice/repository/NoticeRowMapper.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/repository/NoticeRowMapper.java
@@ -11,6 +11,7 @@ public class NoticeRowMapper implements RowMapper<Notice> {
     public Notice mapRow(ResultSet rs, int rowNum) throws SQLException {
         return new Notice(
                 rs.getLong("idx"),
+                rs.getLong("member_idx"),
                 rs.getString("title"),
                 rs.getString("content"),
                 rs.getTimestamp("created_at").toLocalDateTime(),

--- a/backend/src/main/java/dev/be/dorothy/notice/repository/NoticeRowMapper.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/repository/NoticeRowMapper.java
@@ -10,11 +10,12 @@ public class NoticeRowMapper implements RowMapper<Notice> {
     @Override
     public Notice mapRow(ResultSet rs, int rowNum) throws SQLException {
         return new Notice(
-                Long.valueOf(rs.getString("idx")),
+                rs.getLong("idx"),
                 rs.getString("title"),
                 rs.getString("content"),
                 rs.getTimestamp("created_at").toLocalDateTime(),
                 rs.getTimestamp("updated_at").toLocalDateTime(),
+                rs.getLong("views"),
                 Boolean.parseBoolean(rs.getString("is_deleted"))
         );
     }

--- a/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeCreateDto.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeCreateDto.java
@@ -1,8 +1,10 @@
 package dev.be.dorothy.notice.serivce;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class NoticeCreateDto {
     private String title;
     private String content;

--- a/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeCreateDto.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeCreateDto.java
@@ -1,0 +1,9 @@
+package dev.be.dorothy.notice.serivce;
+
+import lombok.Getter;
+
+@Getter
+public class NoticeCreateDto {
+    private String title;
+    private String content;
+}

--- a/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeCreateService.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeCreateService.java
@@ -1,5 +1,5 @@
 package dev.be.dorothy.notice.serivce;
 
 public interface NoticeCreateService {
-    NoticeResDto create(NoticeCreateDto noticeCreateDto);
+    NoticeResDto create(Long memberIdx, NoticeCreateDto noticeCreateDto);
 }

--- a/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeCreateService.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeCreateService.java
@@ -1,0 +1,5 @@
+package dev.be.dorothy.notice.serivce;
+
+public interface NoticeCreateService {
+    NoticeResDto create(NoticeCreateDto noticeCreateDto);
+}

--- a/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeCreateServiceImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeCreateServiceImpl.java
@@ -1,0 +1,33 @@
+package dev.be.dorothy.notice.serivce;
+
+import dev.be.dorothy.exception.BadRequestException;
+import dev.be.dorothy.notice.Notice;
+import dev.be.dorothy.notice.repository.NoticeRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NoticeCreateServiceImpl implements NoticeCreateService {
+    private final NoticeRepository noticeRepository;
+
+    public NoticeCreateServiceImpl(NoticeRepository noticeRepository) {
+        this.noticeRepository = noticeRepository;
+    }
+
+    @Override
+    public NoticeResDto create(NoticeCreateDto noticeCreateDto) {
+        validateCreateData(noticeCreateDto);
+
+        Notice notice = Notice.of(noticeCreateDto.getTitle(), noticeCreateDto.getContent());
+        noticeRepository.save(notice);
+
+        return NoticeResDto.of(
+                notice.getIdx(), notice.getTitle(), notice.getContent(), notice.getUpdatedAt(), notice.getViews()
+        );
+    }
+
+    private void validateCreateData(NoticeCreateDto noticeCreateDto) {
+        if (noticeCreateDto.getTitle().isBlank()) {
+            throw new BadRequestException("요청 인자를 확인하세요.");
+        }
+    }
+}

--- a/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeCreateServiceImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeCreateServiceImpl.java
@@ -14,10 +14,10 @@ public class NoticeCreateServiceImpl implements NoticeCreateService {
     }
 
     @Override
-    public NoticeResDto create(NoticeCreateDto noticeCreateDto) {
+    public NoticeResDto create(Long memberIdx, NoticeCreateDto noticeCreateDto) {
         validateCreateData(noticeCreateDto);
 
-        Notice notice = Notice.of(noticeCreateDto.getTitle(), noticeCreateDto.getContent());
+        Notice notice = Notice.of(memberIdx, noticeCreateDto.getTitle(), noticeCreateDto.getContent());
         noticeRepository.save(notice);
 
         return NoticeResDto.of(

--- a/backend/src/test/java/dev/be/dorothy/notice/repository/NoticeRepositoryTest.java
+++ b/backend/src/test/java/dev/be/dorothy/notice/repository/NoticeRepositoryTest.java
@@ -46,8 +46,8 @@ public class NoticeRepositoryTest {
     @DisplayName("findAll ORDER BY ASC 정상 조회 테스트")
     void findAllWithOrderByAsc() {
         // given
-        Notice noticeOfHyundai = new Notice(null, "현대차그룹 채용 결과 안내", "all pass", LocalDateTime.now().minusDays(1), LocalDateTime.now().minusDays(1), false);
-        Notice noticeOfCodeSquad = new Notice(null, "코드스쿼드 수료 결과 안내", "all pass", LocalDateTime.now(), LocalDateTime.now(), false);
+        Notice noticeOfHyundai = new Notice(null, "현대차그룹 채용 결과 안내", "all pass", LocalDateTime.now().minusDays(1), LocalDateTime.now().minusDays(1), 0L, false);
+        Notice noticeOfCodeSquad = new Notice(null, "코드스쿼드 수료 결과 안내", "all pass", LocalDateTime.now(), LocalDateTime.now(), 0L, false);
         noticeRepository.saveAll(List.of(noticeOfHyundai, noticeOfCodeSquad));
         // when
         List<Notice> notices = noticeRepository.findAll(false);
@@ -63,8 +63,8 @@ public class NoticeRepositoryTest {
     @DisplayName("findAll ORDER BY DESC 정상 조회 테스트")
     void findAllWithOrderByDesc() {
         // given
-        Notice noticeOfHyundai = new Notice(null, "현대차그룹 채용 결과 안내", "all pass", LocalDateTime.now().minusDays(1), LocalDateTime.now().minusDays(1), false);
-        Notice noticeOfCodeSquad = new Notice(null, "코드스쿼드 수료 결과 안내", "all pass", LocalDateTime.now(), LocalDateTime.now(), false);
+        Notice noticeOfHyundai = new Notice(null, "현대차그룹 채용 결과 안내", "all pass", LocalDateTime.now().minusDays(1), LocalDateTime.now().minusDays(1), 0L, false);
+        Notice noticeOfCodeSquad = new Notice(null, "코드스쿼드 수료 결과 안내", "all pass", LocalDateTime.now(), LocalDateTime.now(), 0L, false);
         noticeRepository.saveAll(List.of(noticeOfHyundai, noticeOfCodeSquad));
 
         // when

--- a/backend/src/test/java/dev/be/dorothy/notice/repository/NoticeRepositoryTest.java
+++ b/backend/src/test/java/dev/be/dorothy/notice/repository/NoticeRepositoryTest.java
@@ -1,16 +1,16 @@
 package dev.be.dorothy.notice.repository;
 
+import dev.be.dorothy.member.Member;
+import dev.be.dorothy.member.MemberRole;
+import dev.be.dorothy.member.repository.MemberRepository;
 import dev.be.dorothy.notice.Notice;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -24,31 +24,29 @@ public class NoticeRepositoryTest {
     @Autowired
     NoticeRepository noticeRepository;
 
-    @Test
-    @DisplayName("findOne 정상 조회 테스트")
-    void findOne() {
-        // given
-        Notice noticeOfHyundai = Notice.of("현대차그룹 채용 결과 안내", "all pass");
-        noticeRepository.save(noticeOfHyundai);
-        // when
-        Optional<Notice> optionalNotice = noticeRepository.findOne(noticeOfHyundai.getIdx());
+    @Autowired
+    MemberRepository memberRepository;
 
-        // then
-        assertThat(optionalNotice.isPresent()).isTrue();
-        Notice notice = optionalNotice.get();
-        assertAll(
-                () -> assertThat(notice.getTitle()).isEqualTo("현대차그룹 채용 결과 안내"),
-                () -> assertThat(notice.getContent()).isEqualTo("all pass")
+    @BeforeAll
+    void init() {
+        Member member = memberRepository.save(
+                Member.of("lucas", "a1234567!", "absadas", "lucas", "lucas@example.com", MemberRole.ADMIN)
         );
+
+        Notice noticeOfHyundai = new Notice(null, member.getIdx(), "현대차그룹 채용 결과 안내", "all pass", LocalDateTime.now().minusDays(1), LocalDateTime.now().minusDays(1), 0L, false);
+        Notice noticeOfCodeSquad = new Notice(null, member.getIdx(), "코드스쿼드 수료 결과 안내", "all pass", LocalDateTime.now(), LocalDateTime.now(), 0L, false);
+        noticeRepository.saveAll(List.of(noticeOfHyundai, noticeOfCodeSquad));
+    }
+
+    @AfterAll
+    void clear() {
+        noticeRepository.deleteAll();
+        memberRepository.deleteAll();
     }
 
     @Test
     @DisplayName("findAll ORDER BY ASC 정상 조회 테스트")
     void findAllWithOrderByAsc() {
-        // given
-        Notice noticeOfHyundai = new Notice(null, "현대차그룹 채용 결과 안내", "all pass", LocalDateTime.now().minusDays(1), LocalDateTime.now().minusDays(1), 0L, false);
-        Notice noticeOfCodeSquad = new Notice(null, "코드스쿼드 수료 결과 안내", "all pass", LocalDateTime.now(), LocalDateTime.now(), 0L, false);
-        noticeRepository.saveAll(List.of(noticeOfHyundai, noticeOfCodeSquad));
         // when
         List<Notice> notices = noticeRepository.findAll(false);
 
@@ -63,11 +61,6 @@ public class NoticeRepositoryTest {
     @DisplayName("findAll ORDER BY DESC 정상 조회 테스트")
     void findAllWithOrderByDesc() {
         // given
-        Notice noticeOfHyundai = new Notice(null, "현대차그룹 채용 결과 안내", "all pass", LocalDateTime.now().minusDays(1), LocalDateTime.now().minusDays(1), 0L, false);
-        Notice noticeOfCodeSquad = new Notice(null, "코드스쿼드 수료 결과 안내", "all pass", LocalDateTime.now(), LocalDateTime.now(), 0L, false);
-        noticeRepository.saveAll(List.of(noticeOfHyundai, noticeOfCodeSquad));
-
-        // when
         List<Notice> notices = noticeRepository.findAll(true);
 
         // then

--- a/backend/src/test/java/dev/be/dorothy/notice/service/NoticeCreateServiceTest.java
+++ b/backend/src/test/java/dev/be/dorothy/notice/service/NoticeCreateServiceTest.java
@@ -28,7 +28,7 @@ public class NoticeCreateServiceTest {
         // when then
         BadRequestException exception = assertThrows(
                 BadRequestException.class,
-                () -> noticeCreateService.create(noticeCreateDto)
+                () -> noticeCreateService.create(1L, noticeCreateDto)
         );
         assertThat(exception.getMessage()).isEqualTo("요청 인자를 확인하세요.");
     }

--- a/backend/src/test/java/dev/be/dorothy/notice/service/NoticeCreateServiceTest.java
+++ b/backend/src/test/java/dev/be/dorothy/notice/service/NoticeCreateServiceTest.java
@@ -1,0 +1,35 @@
+package dev.be.dorothy.notice.service;
+
+import dev.be.dorothy.exception.BadRequestException;
+import dev.be.dorothy.notice.serivce.NoticeCreateDto;
+import dev.be.dorothy.notice.serivce.NoticeCreateServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("NoticeCreateService Test")
+@ExtendWith(MockitoExtension.class)
+public class NoticeCreateServiceTest {
+
+    @InjectMocks
+    NoticeCreateServiceImpl noticeCreateService;
+
+    @Test
+    @DisplayName("빈 타이틀로 공지사항 생성 시, 400 예외를 던지는지 테스트")
+    void createWithInvalidData() {
+        // given
+        NoticeCreateDto noticeCreateDto = new NoticeCreateDto("", "all pass");
+
+        // when then
+        BadRequestException exception = assertThrows(
+                BadRequestException.class,
+                () -> noticeCreateService.create(noticeCreateDto)
+        );
+        assertThat(exception.getMessage()).isEqualTo("요청 인자를 확인하세요.");
+    }
+}

--- a/backend/src/test/java/dev/be/dorothy/notice/service/NoticeReadServiceTest.java
+++ b/backend/src/test/java/dev/be/dorothy/notice/service/NoticeReadServiceTest.java
@@ -34,7 +34,7 @@ public class NoticeReadServiceTest {
     void getNotice() {
         // given
         Long noticeId = 1L;
-        Notice notice = new Notice(noticeId, "현대차그룹 채용결과 안내", "all pass", LocalDateTime.now(), LocalDateTime.now(), false);
+        Notice notice = new Notice(noticeId, "현대차그룹 채용결과 안내", "all pass", LocalDateTime.now(), LocalDateTime.now(), 0L, false);
         given(noticeRepository.findOne(noticeId)).willReturn(Optional.of(notice));
 
         // when

--- a/backend/src/test/java/dev/be/dorothy/notice/service/NoticeReadServiceTest.java
+++ b/backend/src/test/java/dev/be/dorothy/notice/service/NoticeReadServiceTest.java
@@ -34,7 +34,7 @@ public class NoticeReadServiceTest {
     void getNotice() {
         // given
         Long noticeId = 1L;
-        Notice notice = new Notice(noticeId, "현대차그룹 채용결과 안내", "all pass", LocalDateTime.now(), LocalDateTime.now(), 0L, false);
+        Notice notice = new Notice(noticeId, 1L, "현대차그룹 채용결과 안내", "all pass", LocalDateTime.now(), LocalDateTime.now(), 0L, false);
         given(noticeRepository.findOne(noticeId)).willReturn(Optional.of(notice));
 
         // when

--- a/backend/src/test/resources/init.sql
+++ b/backend/src/test/resources/init.sql
@@ -4,9 +4,9 @@ drop table if exists `attendance`;
 drop table if exists `track_member`;
 drop table if exists `reservation`;
 drop table if exists `place`;
+drop table if exists `notice`;
 drop table if exists `member`;
 drop table if exists `track`;
-drop table if exists `notice`;
 
 CREATE TABLE IF NOT EXISTS `member`
 (
@@ -79,6 +79,7 @@ CREATE TABLE IF NOT EXISTS `attendance`
 CREATE TABLE IF NOT EXISTS `notice`
 (
     `idx`        int      NOT NULL auto_increment primary key,
+    `member_idx` int	  NOT NULL,
     `title`      TEXT     NOT NULL,
     `content`    TEXT     NOT NULL,
     `views`      int      NOT NULL,
@@ -106,3 +107,5 @@ ALTER TABLE `reservation`
 ALTER TABLE `attendance`
     ADD CONSTRAINT `FK_track_member_TO_attendance_1` FOREIGN KEY (`track_member_idx`)
         REFERENCES `track_member` (`idx`);
+ALTER TABLE `notice` ADD CONSTRAINT `FK_member_TO_notice_1` FOREIGN KEY (`member_idx`)
+    REFERENCES `member` (`idx`);

--- a/backend/src/test/resources/init.sql
+++ b/backend/src/test/resources/init.sql
@@ -81,6 +81,7 @@ CREATE TABLE IF NOT EXISTS `notice`
     `idx`        int      NOT NULL auto_increment primary key,
     `title`      TEXT     NOT NULL,
     `content`    TEXT     NOT NULL,
+    `views`      int      NOT NULL,
     `created_at` datetime NOT NULL DEFAULT current_timestamp,
     `updated_at` datetime NULL     DEFAULT current_timestamp on update current_timestamp,
     `is_deleted` BIT(1)   NULL     DEFAULT 0 COMMENT '0: not deleted, 1: deleted'


### PR DESCRIPTION
# What?
### 공지사항 생성 API 및 비즈니스 로직 구현
### sql.init 수정 (공지사항의 새로운 필드 추가)

# Why?
### 공지사항 생성 API 및 비즈니스 로직 구현
- 요청 유저 권한이 ADMIN이 아닌 경우에는 공지사항 작성 불가
- 요청 데이터 중 제목이 비어있는 경우 작성 불가
### sql.init 수정 (공지사항의 새로운 필드 추가)
- 공지사항 도메인에 조회수(views) 필드가 추가되었음

# How?
### 공지사항 생성 API 및 비즈니스 로직 구현
- 컨트롤러에서 요청 유저의 권한이 ADMIN이 아닌 경우에는 예외를 던진다.
- 서비스 로직에스 요청 데이터를 검증하여 제목이 비어있는 경우 예외를 던진다.
### sql.init 수정 (공지사항의 새로운 필드 추가)
- notice 테이블 생성 ddl에 views 필드 추가
- notice와 member 간 일대다 관계 형성

This closes #130 
