### PR TITLE
공지사항 조회 API 및 조회수 증가 기능 구현

### DIFF
--- a/backend/src/main/java/dev/be/dorothy/notice/controller/NoticeController.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/controller/NoticeController.java
@@ -33,6 +33,16 @@ public class NoticeController {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
+    @GetMapping("/list")
+    public ResponseEntity<CommonResponse> readAll() {
+        CommonResponse response = new CommonResponse(
+                HttpStatus.OK,
+                "공지사항 전체를 성공적으로 조회하였습니다.",
+                noticeReadService.getNotices()
+        );
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
     @PostMapping("")
     public ResponseEntity<CommonResponse> create(
             @RequestBody NoticeCreateDto noticeCreateDto

--- a/backend/src/main/java/dev/be/dorothy/notice/controller/NoticeController.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/controller/NoticeController.java
@@ -3,25 +3,34 @@ package dev.be.dorothy.notice.controller;
 import dev.be.dorothy.common.CommonResponse;
 import dev.be.dorothy.exception.ForbiddenException;
 import dev.be.dorothy.member.MemberRole;
-import dev.be.dorothy.notice.serivce.NoticeCreateDto;
-import dev.be.dorothy.notice.serivce.NoticeCreateService;
-import dev.be.dorothy.notice.serivce.NoticeResDto;
+import dev.be.dorothy.notice.serivce.*;
 import dev.be.dorothy.security.context.ContextHolder;
 import dev.be.dorothy.security.context.MemberDetail;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/notice")
 public class NoticeController {
+    private final NoticeReadService noticeReadService;
     private final NoticeCreateService noticeCreateService;
 
-    public NoticeController(NoticeCreateService noticeCreateService) {
+    public NoticeController(NoticeReadService noticeReadService, NoticeCreateService noticeCreateService) {
+        this.noticeReadService = noticeReadService;
         this.noticeCreateService = noticeCreateService;
+    }
+
+    @GetMapping("{noticeId}")
+    public ResponseEntity<CommonResponse> read(
+            @PathVariable("noticeId") Long noticeId
+    ) {
+        CommonResponse response = new CommonResponse(
+                HttpStatus.OK,
+                "공지사항을 성공적으로 조회하였습니다.",
+                noticeReadService.getNotice(noticeId)
+        );
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
     @PostMapping("")

--- a/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeReadServiceImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeReadServiceImpl.java
@@ -27,7 +27,7 @@ public class NoticeReadServiceImpl implements NoticeReadService {
     public NoticeResDto getNotice(Long noticeId) {
         Notice notice = noticeRepository.findOne(noticeId)
                 .orElseThrow(() -> new BadRequestException("해당 공지사항이 존재하지 않습니다."));
-        Long viewsInRedis = redisDao.inclement(REDIS_KEY + noticeId);
+        Long viewsInRedis = redisDao.increment(REDIS_KEY + noticeId);
         return NoticeResDto.of(
                 notice.getIdx(),
                 notice.getTitle(),

--- a/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeReadServiceImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/serivce/NoticeReadServiceImpl.java
@@ -1,8 +1,10 @@
 package dev.be.dorothy.notice.serivce;
 
+import dev.be.dorothy.aspect.EnableLock;
 import dev.be.dorothy.exception.BadRequestException;
 import dev.be.dorothy.notice.Notice;
 import dev.be.dorothy.notice.repository.NoticeRepository;
+import dev.be.dorothy.redis.RedisDao;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -10,18 +12,28 @@ import java.util.List;
 
 @Service
 public class NoticeReadServiceImpl implements NoticeReadService {
-    private final NoticeRepository noticeRepository;
+    private final String REDIS_KEY = "NOTICE_";
 
-    public NoticeReadServiceImpl(NoticeRepository noticeRepository) {
+    private final NoticeRepository noticeRepository;
+    private final RedisDao redisDao;
+
+    public NoticeReadServiceImpl(NoticeRepository noticeRepository, RedisDao redisDao) {
         this.noticeRepository = noticeRepository;
+        this.redisDao = redisDao;
     }
 
     @Override
+    @EnableLock(key = "#NOTICE")
     public NoticeResDto getNotice(Long noticeId) {
         Notice notice = noticeRepository.findOne(noticeId)
                 .orElseThrow(() -> new BadRequestException("해당 공지사항이 존재하지 않습니다."));
-        // TODO: 현재 views 관련 기능 구현 전
-        return NoticeResDto.of(notice.getIdx(), notice.getTitle(), notice.getContent(), notice.getCreatedAt(), 0L);
+        Long viewsInRedis = redisDao.inclement(REDIS_KEY + noticeId);
+        return NoticeResDto.of(
+                notice.getIdx(),
+                notice.getTitle(),
+                notice.getContent(),
+                notice.getCreatedAt(),
+                notice.getViews() + viewsInRedis);
     }
 
     @Override
@@ -29,10 +41,15 @@ public class NoticeReadServiceImpl implements NoticeReadService {
         List<Notice> notices = noticeRepository.findAll(true);
 
         List<NoticeResDto> noticeResDtos = new ArrayList<>();
-        // TODO: 현재 views 관련 기능 구현 전
+
         for (Notice notice: notices) {
+            String viewsInRedis = redisDao.getValues(REDIS_KEY + notice.getIdx());
             NoticeResDto noticeResDto = NoticeResDto.of(
-                    notice.getIdx(), notice.getTitle(), notice.getContent(), notice.getCreatedAt(), 0L
+                    notice.getIdx(),
+                    notice.getTitle(),
+                    notice.getContent(),
+                    notice.getCreatedAt(),
+                    notice.getViews() + Long.parseLong(viewsInRedis)
             );
             noticeResDtos.add(noticeResDto);
         }

--- a/backend/src/main/java/dev/be/dorothy/redis/RedisDao.java
+++ b/backend/src/main/java/dev/be/dorothy/redis/RedisDao.java
@@ -32,7 +32,7 @@ public class RedisDao {
         }
     }
 
-    public Long inclement(String key) {
+    public Long increment(String key) {
         return redisTemplate.opsForValue().increment(key);
     }
 }

--- a/backend/src/main/java/dev/be/dorothy/redis/RedisDao.java
+++ b/backend/src/main/java/dev/be/dorothy/redis/RedisDao.java
@@ -31,4 +31,8 @@ public class RedisDao {
             redisTemplate.delete(keys);
         }
     }
+
+    public Long inclement(String key) {
+        return redisTemplate.opsForValue().increment(key);
+    }
 }

--- a/backend/src/test/java/dev/be/dorothy/notice/service/NoticeReadServiceTest.java
+++ b/backend/src/test/java/dev/be/dorothy/notice/service/NoticeReadServiceTest.java
@@ -5,6 +5,7 @@ import dev.be.dorothy.notice.Notice;
 import dev.be.dorothy.notice.repository.NoticeRepository;
 import dev.be.dorothy.notice.serivce.NoticeReadServiceImpl;
 import dev.be.dorothy.notice.serivce.NoticeResDto;
+import dev.be.dorothy.redis.RedisDao;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,6 +30,9 @@ public class NoticeReadServiceTest {
     @InjectMocks
     NoticeReadServiceImpl noticeReadService;
 
+    @Mock
+    RedisDao redisDao;
+
     @Test
     @DisplayName("Notice 단일 조회 시, 디비에서 조회한 Notice를 정상적으로 NoticeResDto로 반환하는지 테스트")
     void getNotice() {
@@ -36,6 +40,7 @@ public class NoticeReadServiceTest {
         Long noticeId = 1L;
         Notice notice = new Notice(noticeId, 1L, "현대차그룹 채용결과 안내", "all pass", LocalDateTime.now(), LocalDateTime.now(), 0L, false);
         given(noticeRepository.findOne(noticeId)).willReturn(Optional.of(notice));
+        given(redisDao.inclement("NOTICE_" + noticeId)).willReturn(1L);
 
         // when
         NoticeResDto noticeResDto = noticeReadService.getNotice(noticeId);

--- a/backend/src/test/java/dev/be/dorothy/notice/service/NoticeReadServiceTest.java
+++ b/backend/src/test/java/dev/be/dorothy/notice/service/NoticeReadServiceTest.java
@@ -40,7 +40,7 @@ public class NoticeReadServiceTest {
         Long noticeId = 1L;
         Notice notice = new Notice(noticeId, 1L, "현대차그룹 채용결과 안내", "all pass", LocalDateTime.now(), LocalDateTime.now(), 0L, false);
         given(noticeRepository.findOne(noticeId)).willReturn(Optional.of(notice));
-        given(redisDao.inclement("NOTICE_" + noticeId)).willReturn(1L);
+        given(redisDao.increment("NOTICE_" + noticeId)).willReturn(1L);
 
         // when
         NoticeResDto noticeResDto = noticeReadService.getNotice(noticeId);

--- a/backend/src/test/java/dev/be/dorothy/redis/RedisDaoTest.java
+++ b/backend/src/test/java/dev/be/dorothy/redis/RedisDaoTest.java
@@ -25,4 +25,25 @@ public class RedisDaoTest {
         String value = redisDao.getValues("key");
         assertThat(value).isEqualTo("value");
     }
+
+    @Test
+    @DisplayName("증가 메서드 테스트")
+    void inclement() throws InterruptedException {
+        // given when
+        Thread incKey1 = new Thread(() -> incTest("incKey"));
+        Thread incKey2 = new Thread(() -> incTest("incKey"));
+        incKey1.start();
+        incKey2.start();
+        incKey1.join();
+        incKey2.join();
+
+        // then
+        assertThat(redisDao.getValues("incKey")).isEqualTo("2000");
+    }
+
+    private void incTest(String key) {
+        for (int idx = 0; idx < 1000; idx++) {
+            redisDao.inclement(key);
+        }
+    }
 }

--- a/backend/src/test/java/dev/be/dorothy/redis/RedisDaoTest.java
+++ b/backend/src/test/java/dev/be/dorothy/redis/RedisDaoTest.java
@@ -43,7 +43,7 @@ public class RedisDaoTest {
 
     private void incTest(String key) {
         for (int idx = 0; idx < 1000; idx++) {
-            redisDao.inclement(key);
+            redisDao.increment(key);
         }
     }
 }


### PR DESCRIPTION
# What?
### `RedisDao` `inclement` 메서드 구현
### 공지사항 조회 API 및 조회수 증가 기능 구현

# Why?
### `RedisDao` `inclement` 메서드 구현
레디스 인메모리를 통해 조회수 증가 동시성 문제를 해결하기 때문이다.
### 공지사항 조회 API 및 조회수 증가 기능 구현
사용자가 단일 공지사항 조회를 요청할 때 마다 동시성을 보장하며 조회수를 레디스 인메모리에 1씩 증가시켜야 하기 때문이다.

# How?
### 공지사항 조회 API 및 조회수 증가 기능 구현
- 단일 공지사항 조회 시, 레디스 인메모리에 키 값을 `NOTICE_{notice_idx}`로 조회수를 1씩 증가시킨다.
- 추후 특정 시간에 되면 레디스 인메모리의 공지사항 조회수를 데이터 베이스에 반영 시킨 뒤, 레디스 인메모리에 있는 공지사항 정보를 클리어하는 기능 추가 예정

This closes #142 
