### PR TITLE
매일 자정 모든 트랙 멤버의 당일 출석을 결석으로 초기화하는 기능 구현

### DIFF
--- a/backend/src/main/java/dev/be/dorothy/common/scheduler/AttendanceScheduler.java
+++ b/backend/src/main/java/dev/be/dorothy/common/scheduler/AttendanceScheduler.java
@@ -1,0 +1,40 @@
+package dev.be.dorothy.common.scheduler;
+
+import dev.be.dorothy.attendance.Attendance;
+import dev.be.dorothy.attendance.AttendanceType;
+import dev.be.dorothy.attendance.repository.AttendanceRepository;
+import dev.be.dorothy.track.repository.TrackRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AttendanceScheduler {
+    private final static Logger logger = LoggerFactory.getLogger(AttendanceScheduler.class);
+    private final TrackRepository trackRepository;
+    private final AttendanceRepository attendanceRepository;
+
+    public AttendanceScheduler(TrackRepository trackRepository, AttendanceRepository attendanceRepository) {
+        this.attendanceRepository = attendanceRepository;
+        this.trackRepository = trackRepository;
+    }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void setAttendance() {
+        List<Long> allTrackMemberIdx = trackRepository.getAllTrackMemberIdx();
+        List<Attendance> attendances = new ArrayList<>(allTrackMemberIdx.size());
+
+        for (Long trackMemberIdx: allTrackMemberIdx) {
+            Attendance attendance = new Attendance(trackMemberIdx, LocalDate.now(), LocalTime.now(), AttendanceType.ABSENT);
+            attendances.add(attendance);
+        }
+
+        attendanceRepository.saveAll(attendances);
+        logger.info("current time : {}, init {} members attendance", LocalDateTime.now(), allTrackMemberIdx.size());
+    }
+}

--- a/backend/src/main/java/dev/be/dorothy/config/SchedulerConfig.java
+++ b/backend/src/main/java/dev/be/dorothy/config/SchedulerConfig.java
@@ -1,6 +1,8 @@
 package dev.be.dorothy.config;
 
-import dev.be.dorothy.common.scheduler.ExampleScheduler;
+import dev.be.dorothy.attendance.repository.AttendanceRepository;
+import dev.be.dorothy.common.scheduler.AttendanceScheduler;
+import dev.be.dorothy.track.repository.TrackRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -13,6 +15,14 @@ import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 public class SchedulerConfig implements SchedulingConfigurer {
     private static final int POOL_SIZE = 10;
 
+    private final TrackRepository trackRepository;
+    private final AttendanceRepository attendanceRepository;
+
+    public SchedulerConfig(TrackRepository trackRepository, AttendanceRepository attendanceRepository) {
+        this.trackRepository = trackRepository;
+        this.attendanceRepository = attendanceRepository;
+    }
+
     @Override
     public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
         ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
@@ -24,11 +34,8 @@ public class SchedulerConfig implements SchedulingConfigurer {
         taskRegistrar.setTaskScheduler(threadPoolTaskScheduler);
     }
 
-    /** NOTE: Scheduler 예시를 확인할 수 있는 ExampleScheduler 빈 주입 부분
-     *  NOTE: 아래 주석을 해제한 뒤 어플리케이션을 실행하면 동작
-     */
-//    @Bean
-//    public ExampleScheduler getExampleScheduler() {
-//        return new ExampleScheduler();
-//    }
+    @Bean
+    public AttendanceScheduler getAttendanceScheduler() {
+        return new AttendanceScheduler(trackRepository, attendanceRepository);
+    }
 }

--- a/backend/src/main/java/dev/be/dorothy/track/repository/TrackRepository.java
+++ b/backend/src/main/java/dev/be/dorothy/track/repository/TrackRepository.java
@@ -12,6 +12,9 @@ import java.util.Optional;
 
 public interface TrackRepository extends CrudRepository<Track, Long> {
 
+    @Query("select idx from track_member where is_deleted = 0 and role = 'MEMBER'")
+    List<Long> getAllTrackMemberIdx();
+
     @Query("select a.idx, a.name, a.image, a.created_at, a.updated_at from track a inner join track_member b on a.idx = b.track_idx where b.is_deleted = 0 and a.is_deleted = 0 and b.member_idx = :userIdx")
     List<TrackResDto> findByMemberId(@Param("userIdx") Long idx);
 

--- a/backend/src/test/java/dev/be/dorothy/track/repository/TrackRepositoryTest.java
+++ b/backend/src/test/java/dev/be/dorothy/track/repository/TrackRepositoryTest.java
@@ -36,7 +36,16 @@ public class TrackRepositoryTest {
                 MemberRole.MEMBER
         );
 
-        memberRepository.save(member);
+        Member lucas = Member.of(
+                "lucas",
+                "abcd1234",
+                "2p7VxertGPCkNfnr",
+                "lucas",
+                "lucas@example.com",
+                MemberRole.MEMBER
+        );
+
+        memberRepository.saveAll(List.of(member, lucas));
 
         Track track = new Track(
                 "hyundai",
@@ -46,6 +55,12 @@ public class TrackRepositoryTest {
         trackRepository.save(track);
         trackRepository.saveTrackMember(
                 member.getIdx(),
+                track.getIdx(),
+                MemberRole.MEMBER.name(),
+                LocalDateTime.now().toString(),
+                false);
+        trackRepository.saveTrackMember(
+                lucas.getIdx(),
                 track.getIdx(),
                 MemberRole.MEMBER.name(),
                 LocalDateTime.now().toString(),
@@ -92,5 +107,12 @@ public class TrackRepositoryTest {
         Optional<Long> idx = trackRepository.getTrackMemberIdx(999L, trackIdx);
 
         assertThat(idx.isPresent()).isFalse();
+    }
+
+    @Test
+    @DisplayName("모든 트랙 멤버 idx 조회 테스트")
+    void getAllTrackIdx() {
+        List<Long> allTrackMemberIdx = trackRepository.getAllTrackMemberIdx();
+        assertThat(allTrackMemberIdx.size()).isEqualTo(2L);
     }
 }


### PR DESCRIPTION
# What?
매일 자정이 되면 모든 트랙 멤버의 오늘 출석을 결석으로 모두 초기화

# Why?
기본적으로 새로운 요일이 되면 우선 적으로 모든 트랙의 모든 멤버의 출석 현황을 결석으로 처리하기 위해

# How?
1. 모든 트랙 멤버 idx를 조회한다.
2. 모든 트랙 멤버의 idx를 사용하여 모든 트랙 멤버의 오늘 출석을 결석으로 데이터를 넣는다.

This closes #152 
