### PR TITLE
인메모리에 존재하는 당일 공지사항 조회수를 디비와 동기화 시키는 기능 구현

### DIFF
--- a/backend/src/main/java/dev/be/dorothy/common/scheduler/NoticeViewsSyncScheduler.java
+++ b/backend/src/main/java/dev/be/dorothy/common/scheduler/NoticeViewsSyncScheduler.java
@@ -1,0 +1,39 @@
+package dev.be.dorothy.common.scheduler;
+
+import dev.be.dorothy.notice.Notice;
+import dev.be.dorothy.notice.repository.NoticeRepository;
+import dev.be.dorothy.redis.RedisDao;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.Set;
+
+public class NoticeViewsSyncScheduler {
+    private final static Logger logger = LoggerFactory.getLogger(NoticeViewsSyncScheduler.class);
+    private final NoticeRepository noticeRepository;
+    private final RedisDao redisDao;
+
+    public NoticeViewsSyncScheduler(NoticeRepository noticeRepository, RedisDao redisDao) {
+        this.noticeRepository = noticeRepository;
+        this.redisDao = redisDao;
+    }
+
+    @Scheduled(cron = "0 0 2 * * *")
+    public void syncNoticeViews() {
+        Set<String> keys = redisDao.keys("NOTICE*");
+        for (String key: keys) {
+            Long noticeId = Long.parseLong(key.replace("NOTICE_", ""));
+            Optional<Notice> optionalNotice = noticeRepository.findOne(noticeId);
+            if (optionalNotice.isEmpty()) {
+                continue;
+            }
+            Long totalViews = optionalNotice.get().getViews() + Long.parseLong(redisDao.getValues("NOTICE_" + noticeId));
+            noticeRepository.updateViews(noticeId, totalViews);
+        }
+        redisDao.clear("NOTICE*");
+        logger.info("current local date time : {}, sync views total {}", LocalDateTime.now(), keys.size());
+    }
+}

--- a/backend/src/main/java/dev/be/dorothy/config/SchedulerConfig.java
+++ b/backend/src/main/java/dev/be/dorothy/config/SchedulerConfig.java
@@ -4,7 +4,6 @@ package dev.be.dorothy.config;
 import dev.be.dorothy.common.scheduler.NoticeViewsSyncScheduler;
 import dev.be.dorothy.notice.repository.NoticeRepository;
 import dev.be.dorothy.redis.RedisDao;
-
 import dev.be.dorothy.attendance.repository.AttendanceRepository;
 import dev.be.dorothy.common.scheduler.AttendanceScheduler;
 import dev.be.dorothy.track.repository.TrackRepository;
@@ -20,20 +19,17 @@ import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 @EnableScheduling
 public class SchedulerConfig implements SchedulingConfigurer {
     private static final int POOL_SIZE = 10;
-    
     private final TrackRepository trackRepository;
     private final AttendanceRepository attendanceRepository;
     private final NoticeRepository noticeRepository;
     private final RedisDao redisDao;
 
-    public SchedulerConfig(NoticeRepository noticeRepository, RedisDao redisDao) {
-        this.noticeRepository = noticeRepository;
-        this.redisDao = redisDao;
-    }
 
-    public SchedulerConfig(TrackRepository trackRepository, AttendanceRepository attendanceRepository) {
+    public SchedulerConfig(TrackRepository trackRepository, AttendanceRepository attendanceRepository, NoticeRepository noticeRepository, RedisDao redisDao) {
         this.trackRepository = trackRepository;
         this.attendanceRepository = attendanceRepository;
+        this.noticeRepository = noticeRepository;
+        this.redisDao = redisDao;
     }
 
     @Override
@@ -50,6 +46,7 @@ public class SchedulerConfig implements SchedulingConfigurer {
     @Bean
     public NoticeViewsSyncScheduler getNoticeViewsSyncScheduler() {
         return new NoticeViewsSyncScheduler(noticeRepository, redisDao);
+    }
 
     @Bean
     public AttendanceScheduler getAttendanceScheduler() {

--- a/backend/src/main/java/dev/be/dorothy/config/SchedulerConfig.java
+++ b/backend/src/main/java/dev/be/dorothy/config/SchedulerConfig.java
@@ -1,6 +1,8 @@
 package dev.be.dorothy.config;
 
-import dev.be.dorothy.common.scheduler.ExampleScheduler;
+import dev.be.dorothy.common.scheduler.NoticeViewsSyncScheduler;
+import dev.be.dorothy.notice.repository.NoticeRepository;
+import dev.be.dorothy.redis.RedisDao;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -12,6 +14,13 @@ import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 @EnableScheduling
 public class SchedulerConfig implements SchedulingConfigurer {
     private static final int POOL_SIZE = 10;
+    private final NoticeRepository noticeRepository;
+    private final RedisDao redisDao;
+
+    public SchedulerConfig(NoticeRepository noticeRepository, RedisDao redisDao) {
+        this.noticeRepository = noticeRepository;
+        this.redisDao = redisDao;
+    }
 
     @Override
     public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
@@ -24,11 +33,8 @@ public class SchedulerConfig implements SchedulingConfigurer {
         taskRegistrar.setTaskScheduler(threadPoolTaskScheduler);
     }
 
-    /** NOTE: Scheduler 예시를 확인할 수 있는 ExampleScheduler 빈 주입 부분
-     *  NOTE: 아래 주석을 해제한 뒤 어플리케이션을 실행하면 동작
-     */
-//    @Bean
-//    public ExampleScheduler getExampleScheduler() {
-//        return new ExampleScheduler();
-//    }
+    @Bean
+    public NoticeViewsSyncScheduler getNoticeViewsSyncScheduler() {
+        return new NoticeViewsSyncScheduler(noticeRepository, redisDao);
+    }
 }

--- a/backend/src/main/java/dev/be/dorothy/notice/repository/NoticeRepository.java
+++ b/backend/src/main/java/dev/be/dorothy/notice/repository/NoticeRepository.java
@@ -1,7 +1,12 @@
 package dev.be.dorothy.notice.repository;
 
 import dev.be.dorothy.notice.Notice;
+import org.springframework.data.jdbc.repository.query.Modifying;
+import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.CrudRepository;
 
 public interface NoticeRepository extends CrudRepository<Notice, Long>, CustomNoticeRepository {
+    @Query("UPDATE `notice` SET views = :views WHERE idx = :idx;")
+    @Modifying
+    void updateViews(Long idx, Long views);
 }

--- a/backend/src/main/java/dev/be/dorothy/redis/RedisDao.java
+++ b/backend/src/main/java/dev/be/dorothy/redis/RedisDao.java
@@ -35,4 +35,15 @@ public class RedisDao {
     public Long increment(String key) {
         return redisTemplate.opsForValue().increment(key);
     }
+
+    public Set<String> keys(String keyPattern) {
+        return redisTemplate.keys(keyPattern);
+    }
+
+    public void clear(String keyPattern) {
+        Set<String> keys = keys(keyPattern);
+        for (String key: keys) {
+            redisTemplate.delete(key);
+        }
+    }
 }

--- a/backend/src/test/java/dev/be/dorothy/redis/RedisDaoTest.java
+++ b/backend/src/test/java/dev/be/dorothy/redis/RedisDaoTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.Set;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(classes = {RedisConfig.class, RedisDao.class})
@@ -45,5 +47,36 @@ public class RedisDaoTest {
         for (int idx = 0; idx < 1000; idx++) {
             redisDao.increment(key);
         }
+    }
+
+    @Test
+    @DisplayName("키 패턴으로 조회 테스트")
+    void keys() {
+        // given
+        redisDao.setValues("PAT_1_A", "A");
+        redisDao.setValues("PAT_1_B", "B");
+        redisDao.setValues("PAT_2_c", "C");
+
+        // when
+        Set<String> keys = redisDao.keys("PAT_1*");
+
+        // then
+        assertThat(keys.size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("키 패턴으로 삭제 테스트")
+    void clearByKeyPattern() {
+        // given
+        redisDao.setValues("DEL_1_A", "A");
+        redisDao.setValues("DEL_1_B", "B");
+        redisDao.setValues("DEL_2_c", "C");
+
+        // when
+        redisDao.clear("DEL_1*");
+        Set<String> keys = redisDao.keys("DEL_1*");
+
+        // then
+        assertThat(keys.size()).isEqualTo(0);
     }
 }


### PR DESCRIPTION
# What?
### `RedisDao` `keys`메서드와 `clear`메서드 구현
### 인메모리에 존재하는 당일 공지사항 조회수를 디비와 동기화 시키는 기능 구현

# Why?
### `RedisDao` `keys`메서드와 `clear`메서드 구현
스케줄러 진행을 위해 인메모리에서 특정 키패턴으로 데이터 셋 조회가 필요하기 때문에
스케줄러가 진행된 후 인메모리에서 필요없는 데이터를 제거하기 위해

### 인메모리에 존재하는 당일 공지사항 조회수를 디비와 동기화 시키는 기능 구현
조회서 동시성 문제를 해결하기 위해 실제 조회수 증가는 인메모리를 사용한다. 따라서 레디스와 디비의 조회수 동기화 과정 진행 필요

# How?
### `RedisDao` `keys`메서드와 `clear`메서드 구현
- `RedisTemplate`의 `keys` 메서드 활용

### 인메모리에 존재하는 당일 공지사항 조회수를 디비와 동기화 시키는 기능 구현
- `NoticeRepository`에서 공지 정보를 가져와 디비 조회수와 레디스 조회수를 더하여 업데이트 한다.

This closes #153 
