### PR TITLE
예약 현황 조회 시 연속된 예약에 대한 병합 처리 구현 

### DIFF
--- a/backend/src/main/java/dev/be/dorothy/reservation/repository/PlaceRepository.java
+++ b/backend/src/main/java/dev/be/dorothy/reservation/repository/PlaceRepository.java
@@ -32,12 +32,12 @@ public interface PlaceRepository extends CrudRepository<Place, Long> {
     @Query("delete from reservation")
     void deleteAllReservation();
 
-    @Query("select place_idx, start_time from reservation where place_idx = :placeIdx")
+    @Query("select place_idx, start_time, end_time from reservation where place_idx = :placeIdx")
     List<ReservationResDto> findReservationByPlaceId(@Param("placeIdx") Long placeIdx);
 
-    @Query("select place_idx, start_time from reservation where member_idx = :memberIdx")
+    @Query("select place_idx, start_time, end_time from reservation where member_idx = :memberIdx")
     List<ReservationResDto> findReservationByMemberId(@Param("memberIdx") Long memberIdx);
 
-    @Query("select place_idx, start_time from reservation where idx = :idx")
+    @Query("select * from(select place_idx, start_time, end_time from reservation where idx = :idx order by start_time) group by place_idx")
     Optional<ReservationResDto> findReservationById(@Param("idx") int idx);
 }

--- a/backend/src/main/java/dev/be/dorothy/reservation/repository/PlaceRepository.java
+++ b/backend/src/main/java/dev/be/dorothy/reservation/repository/PlaceRepository.java
@@ -35,9 +35,9 @@ public interface PlaceRepository extends CrudRepository<Place, Long> {
     @Query("select place_idx, start_time, end_time from reservation where place_idx = :placeIdx")
     List<ReservationResDto> findReservationByPlaceId(@Param("placeIdx") Long placeIdx);
 
-    @Query("select place_idx, start_time, end_time from reservation where member_idx = :memberIdx")
+    @Query("select place_idx, start_time, end_time from reservation where member_idx = :memberIdx order by start_time")
     List<ReservationResDto> findReservationByMemberId(@Param("memberIdx") Long memberIdx);
 
-    @Query("select * from(select place_idx, start_time, end_time from reservation where idx = :idx order by start_time) group by place_idx")
+    @Query("select place_idx, start_time, end_time from reservation where idx = :idx order by start_time")
     Optional<ReservationResDto> findReservationById(@Param("idx") int idx);
 }

--- a/backend/src/main/java/dev/be/dorothy/reservation/service/PlaceReservationServiceImpl.java
+++ b/backend/src/main/java/dev/be/dorothy/reservation/service/PlaceReservationServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -26,7 +27,7 @@ public class PlaceReservationServiceImpl implements PlaceReservationService{
         List<Map<String, String>> startTimeList = (ArrayList) startTimeObj;
         List<ReservationResDto> resultList = new ArrayList<>();
         for(Map<String, String> startTimeStr : startTimeList){
-            LocalTime startTime = LocalTime.parse(startTimeStr.get("time"));
+            LocalTime startTime = LocalTime.parse(startTimeStr.get("time")).withSecond(0);
             String key = RedissonKeyUtils.keyBuilder(placeIdx, startTime);
             if(!placeReservationManagerImpl.reservePlace(key, memberIdx)){
                 resultList.add(ReservationResDto.of(placeIdx, startTime, startTime.plusMinutes(15)));
@@ -46,24 +47,40 @@ public class PlaceReservationServiceImpl implements PlaceReservationService{
     @Override
     public List<ReservationResDto> readMyReservations(Long memberIdx) {
         List<ReservationResDto> reservations = placeRepository.findReservationByMemberId(memberIdx);
-        List<ReservationResDto> resultList = new ArrayList<>();
-
         if(reservations.isEmpty())
             return reservations;
+        Map<Long, ArrayList<ReservationResDto>> reservationMap = reservationListToMap(reservations);
+        return getResultList(reservationMap);
+    }
 
-        ReservationResDto tempReservation = reservations.get(0);
-
-        for(int i = 1 ; i < reservations.size(); i++){
-            ReservationResDto reservation = reservations.get(i);
-            if(!reservation.getStartTime().equals(tempReservation.getEndTime()) || !reservation.getPlaceIdx().equals(tempReservation.getPlaceIdx()) ) {
-                resultList.add(tempReservation);
-                tempReservation = reservation;
-            }else{
-                tempReservation.setEndTime(reservation.getEndTime());
+    private List<ReservationResDto> getResultList(Map<Long, ArrayList<ReservationResDto>> reservationMap) {
+        List<ReservationResDto> resultList = new ArrayList<>();
+        reservationMap.forEach((idx, reserve)->{
+            ReservationResDto tempReservation = reserve.get(0);
+            for(int i = 1 ; i < reserve.size(); i++){
+                ReservationResDto reservation = reserve.get(i);
+                if(!reservation.getStartTime().equals(tempReservation.getEndTime()) || !reservation.getPlaceIdx().equals(tempReservation.getPlaceIdx()) ) {
+                    resultList.add(tempReservation);
+                    tempReservation = reservation;
+                }else{
+                    tempReservation.setEndTime(reservation.getEndTime());
+                }
             }
-        }
-        resultList.add(tempReservation);
+            resultList.add(tempReservation);
+        });
         return resultList;
+    }
+
+    private Map<Long, ArrayList<ReservationResDto>> reservationListToMap(List<ReservationResDto> reservations) {
+        Map<Long, ArrayList<ReservationResDto>> reservationMap = new HashMap<>();
+        reservations.forEach(reservation -> {
+            if(reservationMap.get(reservation.getPlaceIdx()) != null) {
+                reservationMap.get(reservation.getPlaceIdx()).add(reservation);
+            }else{
+                reservationMap.put(reservation.getPlaceIdx(), new ArrayList<>(List.of(reservation)));
+            }
+        });
+        return reservationMap;
     }
 
 }

--- a/backend/src/main/java/dev/be/dorothy/reservation/service/ReservationResDto.java
+++ b/backend/src/main/java/dev/be/dorothy/reservation/service/ReservationResDto.java
@@ -1,17 +1,27 @@
 package dev.be.dorothy.reservation.service;
 
+import java.time.LocalTime;
+
 public class ReservationResDto {
 
     private final Long placeIdx;
     private final String startTime;
+    private String endTime;
 
-    public ReservationResDto(Long placeIdx, String startTime) {
+    public ReservationResDto(Long placeIdx, String startTime, String endTime) {
         this.placeIdx = placeIdx;
         this.startTime = startTime.substring(0, startTime.lastIndexOf(":"));
+        this.endTime = endTime.substring(0, endTime.lastIndexOf(":"));
     }
 
-    public static ReservationResDto of(Long placeIdx, String time) {
-        return new ReservationResDto(placeIdx, time);
+    private ReservationResDto(Long placeIdx, LocalTime startTime, LocalTime endTime) {
+        this.placeIdx = placeIdx;
+        this.startTime = startTime.toString();
+        this.endTime = endTime.toString();
+    }
+
+    public static ReservationResDto of(Long placeIdx, LocalTime startTime, LocalTime endTime) {
+        return new ReservationResDto(placeIdx, startTime, endTime);
     }
 
     public Long getPlaceIdx() {
@@ -20,5 +30,13 @@ public class ReservationResDto {
 
     public String getStartTime() {
         return startTime;
+    }
+
+    public String getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(String endTime) {
+        this.endTime = endTime;
     }
 }

--- a/backend/src/main/java/dev/be/dorothy/reservation/service/ReservationResDto.java
+++ b/backend/src/main/java/dev/be/dorothy/reservation/service/ReservationResDto.java
@@ -14,14 +14,8 @@ public class ReservationResDto {
         this.endTime = endTime.substring(0, endTime.lastIndexOf(":"));
     }
 
-    private ReservationResDto(Long placeIdx, LocalTime startTime, LocalTime endTime) {
-        this.placeIdx = placeIdx;
-        this.startTime = startTime.toString();
-        this.endTime = endTime.toString();
-    }
-
     public static ReservationResDto of(Long placeIdx, LocalTime startTime, LocalTime endTime) {
-        return new ReservationResDto(placeIdx, startTime, endTime);
+        return new ReservationResDto(placeIdx, startTime.toString().concat(":00"), endTime.toString().concat(":00"));
     }
 
     public Long getPlaceIdx() {

--- a/backend/src/test/java/dev/be/dorothy/reservation/service/PlaceReservationServiceImplTest.java
+++ b/backend/src/test/java/dev/be/dorothy/reservation/service/PlaceReservationServiceImplTest.java
@@ -1,0 +1,40 @@
+package dev.be.dorothy.reservation.service;
+
+import dev.be.dorothy.reservation.repository.PlaceRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.List;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+@DisplayName("PlaceReservaionService Test")
+@ExtendWith(MockitoExtension.class)
+class PlaceReservationServiceImplTest {
+
+    @Mock
+    PlaceRepository placeRepository;
+
+    @InjectMocks
+    PlaceReservationServiceImpl placeReservationService;
+
+    @Test
+    @DisplayName("나의 예약 조회 시 병합 처리 테스트")
+    void reservationCombinationTest(){
+        // given
+        Long memberIdx = 1L;
+        List<ReservationResDto> reservations = List.of(new ReservationResDto(1L, "12:00:00", "12:15:00")
+                                                      ,new ReservationResDto(2L, "12:00:00", "12:15:00")
+                                                      ,new ReservationResDto(1L, "12:15:00", "12:30:00")
+                                                      ,new ReservationResDto(2L, "12:15:00", "12:30:00"));
+        given(placeRepository.findReservationByMemberId(memberIdx)).willReturn(reservations);
+
+        //when
+        placeRepository.findReservationByMemberId(memberIdx);
+        List<ReservationResDto> reservationResDtos = placeReservationService.readMyReservations(memberIdx);
+        assertThat(reservationResDtos).hasSize(2);
+    }
+}


### PR DESCRIPTION
# What?
PlaceReservationServiceImpl의 readMyReservation 메소드 수정
PlaceRepository의 reservation 테이블 관련 쿼리문 수정

# Why?
하나의 공간에 대한 예약이 연속적으로 되어있을 때, 이를 합친 상태로 응답하기 위하여

# How?
placeRepository에서 start_time을 기준으로 예약 현황을 가져온 뒤,
이를 place_idx를 key로 하여 hashMap에 저장한 뒤
각 place마다 예약 시간을 차례로 비교하며 연속된 사항이 있을 경우 병합

This closes #179 
